### PR TITLE
Fix unscheduled task mapping in OrientationCalendar

### DIFF
--- a/OrientationCalendar
+++ b/OrientationCalendar
@@ -233,8 +233,8 @@ function App(){
       wk: w.wk,
       title: w.title,
       items: (w.tasks||[])
-        .filter(t=>!t.scheduled_for)
-        .map((t,ti)=> ({ label: t.title, wi, ti }))
+        .map((t, ti) => (!t.scheduled_for ? { label: t.title, wi, ti } : null))
+        .filter(Boolean)
     }));
   }, [weeks]);
 


### PR DESCRIPTION
## Summary
- retain original indices when generating unscheduled task items for the Assign modal
- filter null entries after mapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c224ec2adc832c94820591ed6e24b5