### PR TITLE
Add accessibility labels to calendar badges

### DIFF
--- a/OrientationCalendar
+++ b/OrientationCalendar
@@ -344,6 +344,8 @@ function App(){
                       draggable
                       data-wi={it.wi}
                       data-ti={it.ti}
+                      title={it.label}
+                      aria-label={it.label}
                       onDragStart={handleDragStart}
                       onDragEnd={handleDragEnd}
                       onTouchStart={handleDragStart}


### PR DESCRIPTION
## Summary
- add title and aria-label on each calendar badge for better accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2275297d4832ca6d182510b1eb21a