### PR TITLE
feat: add aria labels to assign modal buttons

### DIFF
--- a/OrientationCalendar
+++ b/OrientationCalendar
@@ -275,6 +275,7 @@ function App(){
                           key={i}
                           className="btn btn-outline justify-start truncate text-left"
                           title={it.label}
+                          aria-label={it.label}
                           onClick={()=> handleAssign(it)}
                         >
                           {it.label}


### PR DESCRIPTION
## Summary
- add aria-labels to Assign modal buttons for better accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c228051560832c84164d0a32bffa80