### PR TITLE
Hide lightweight auth controls after login

### DIFF
--- a/OrientationCalendar
+++ b/OrientationCalendar
@@ -637,6 +637,19 @@ function Root(){
     })();
   }, []);
 
+  // Hide lightweight auth toggle/panel once user is authenticated
+  useEffect(() => {
+    const toggle = document.getElementById('lite-auth-toggle');
+    const panel = document.getElementById('lite-auth');
+    if (me) {
+      toggle?.classList.add('hidden');
+      panel?.classList.add('hidden');
+    } else {
+      toggle?.classList.remove('hidden');
+      panel?.classList.add('hidden');
+    }
+  }, [me]);
+
   if (!checked){
     return (
       <div className="min-h-screen flex items-center justify-center w-full">


### PR DESCRIPTION
## Summary
- Hide quick auth toggle and panel once a user is authenticated
- Ensure toggle reappears when user logs out

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c31ec758cc832c8165aad1ced9ea0c