### PR TITLE
Filter tasks by program id

### DIFF
--- a/OrientationCalendar
+++ b/OrientationCalendar
@@ -84,7 +84,7 @@ const dayjsIso = dayjs.extend(window.dayjs_plugin_isoWeek);
 /* Use same origin the page is served from */
 const API = window.location.origin;
 const qs = new URLSearchParams(location.search);
-const QS_PROGRAM_ID = qs.get('program_id') || localStorage.getItem('anx_program_id') || null;
+let QS_PROGRAM_ID = qs.get('program_id') || localStorage.getItem('anx_program_id') || null;
 
 /* Helpers */
 const fmt = (d) => dayjs(d).format('MMM D, YYYY');
@@ -181,6 +181,21 @@ async function apiLogout(){
   await fetch(`${API}/auth/logout`, { method:'POST', credentials:'include' });
 }
 
+async function apiGetPrefs(){
+  const r = await fetch(`${API}/prefs`, { credentials:'include' });
+  if(!r.ok) return {};
+  return r.json();
+}
+async function apiPatchPrefs(data){
+  const r = await fetch(`${API}/prefs`, {
+    method:'PATCH', credentials:'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if(!r.ok) throw new Error('PATCH /prefs failed');
+  return r.json();
+}
+
 /* ---- TASK helpers ---- */
 async function apiGetTasks(params = {}){
   const usp = new URLSearchParams(params);
@@ -266,7 +281,16 @@ function App({ me, onSignOut }){
   useEffect(() => {
     async function load() {
       try {
-        const rows = await apiGetTasks({ trainee: encodeURIComponent(trainee) });
+        if (!QS_PROGRAM_ID) {
+          const prefs = await apiGetPrefs();
+          QS_PROGRAM_ID = prefs.program_id || null;
+          if (QS_PROGRAM_ID) localStorage.setItem('anx_program_id', QS_PROGRAM_ID);
+        } else {
+          localStorage.setItem('anx_program_id', QS_PROGRAM_ID);
+          try { await apiPatchPrefs({ program_id: QS_PROGRAM_ID }); } catch (e) {}
+        }
+        if (!QS_PROGRAM_ID) return;
+        const rows = await apiGetTasks({ program_id: QS_PROGRAM_ID });
         const byWeek = {};
         rows.forEach(r => {
           const wk = r.week_number || 0;
@@ -347,7 +371,6 @@ function App({ me, onSignOut }){
     if(!label) return;
     try {
       const created = await apiCreateTask({
-        trainee,
         label,
         week_number: weeks[wi].wk,
         program_id: QS_PROGRAM_ID

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -201,12 +201,13 @@ app.patch('/prefs', ensureAuth, async (req, res) => {
 
 app.get('/tasks', ensureAuth, async (req, res) => {
   try {
-    const { start, end } = req.query;
+    const { start, end, program_id } = req.query;
     const conds = ['user_id = $1'];
     const vals = [req.user.id];
 
     if (start) { vals.push(start); conds.push(`scheduled_for >= $${vals.length}`); }
     if (end)   { vals.push(end);   conds.push(`scheduled_for <= $${vals.length}`); }
+    if (program_id) { vals.push(program_id); conds.push(`program_id = $${vals.length}`); }
 
     const where = `WHERE ${conds.join(' AND ')}`;
     const sql = `SELECT * FROM public.orientation_tasks ${where}


### PR DESCRIPTION
## Summary
- Filter server task queries by optional program_id
- Track and persist program selection in client preferences
- Remove trainee param and fetch tasks for selected program

## Testing
- `node --check orientation_server.js`


------
https://chatgpt.com/codex/tasks/task_e_68c32107fecc832ca96c44e872249e40