### PR TITLE
Handle logout without session

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -159,10 +159,12 @@ app.post('/auth/local/login', async (req, res) => {
 });
 
 // Logout (works for both)
-app.post('/auth/logout', (req, res) => {
-  req.logout?.(() => {});
-  req.session?.destroy(() => {});
-  res.json({ ok: true });
+app.post('/auth/logout', (req, res, next) => {
+  if (!req.session) return res.json({ ok: true });
+  req.logout(err => {
+    if (err) return next(err);
+    req.session.destroy(() => res.json({ ok: true }));
+  });
 });
 
 // Me + Preferences


### PR DESCRIPTION
## Summary
- Safely handle `/auth/logout` when no session exists
- Destroy session in logout callback

## Testing
- `node --check orientation_server.js`


------
https://chatgpt.com/codex/tasks/task_e_68c32609112c832c8bb27595dd4ec80b