### PR TITLE
feat: add password reset flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/__tests__/passwordReset.test.js
+++ b/__tests__/passwordReset.test.js
@@ -1,0 +1,83 @@
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+const crypto = require('crypto');
+const { newDb } = require('pg-mem');
+
+// Mock pg to use pg-mem
+const db = newDb();
+const { Pool } = db.adapters.createPg();
+jest.mock('pg', () => ({ Pool }));
+
+// Mock nodemailer to avoid real email sending
+const sendMailMock = jest.fn().mockResolvedValue(true);
+jest.mock('nodemailer', () => ({
+  createTransport: () => ({ sendMail: sendMailMock })
+}));
+
+// Require app after mocks
+const { app, pool } = require('../orientation_server.js');
+
+beforeAll(async () => {
+  await pool.query(`
+    create table public.users (
+      id uuid primary key,
+      username text unique,
+      email text,
+      full_name text,
+      password_hash text,
+      provider text,
+      password_reset_token text,
+      password_reset_expires timestamptz,
+      updated_at timestamptz
+    );
+  `);
+});
+
+afterEach(async () => {
+  await pool.query('delete from public.users');
+  sendMailMock.mockClear();
+});
+
+test('forgot sets token and expiry', async () => {
+  const id = crypto.randomUUID();
+  const hash = await bcrypt.hash('oldpass', 1);
+  await pool.query('insert into public.users(id, username, email, password_hash, provider) values ($1,$2,$3,$4,$5)', [id, 'alice', 'alice@example.com', hash, 'local']);
+
+  await request(app).post('/auth/local/forgot').send({ identifier: 'alice' }).expect(200);
+
+  const { rows } = await pool.query('select password_reset_token, password_reset_expires from public.users where id=$1', [id]);
+  expect(rows[0].password_reset_token).toBeTruthy();
+  expect(rows[0].password_reset_token.length).toBe(64);
+  expect(new Date(rows[0].password_reset_expires) > new Date()).toBe(true);
+  expect(sendMailMock).toHaveBeenCalled();
+});
+
+test('reset rejects expired token', async () => {
+  const id = crypto.randomUUID();
+  const hash = await bcrypt.hash('oldpass', 1);
+  const token = 'tok123';
+  const hashed = crypto.createHash('sha256').update(token).digest('hex');
+  const past = new Date(Date.now() - 1000);
+  await pool.query('insert into public.users(id, username, password_hash, provider, password_reset_token, password_reset_expires) values ($1,$2,$3,$4,$5,$6)', [id, 'bob', hash, 'local', hashed, past]);
+
+  await request(app).post('/auth/local/reset').send({ token, password: 'newpass123' }).expect(400);
+
+  const { rows } = await pool.query('select password_reset_token from public.users where id=$1', [id]);
+  expect(rows[0].password_reset_token).toBe(hashed);
+});
+
+test('reset updates password and clears fields', async () => {
+  const id = crypto.randomUUID();
+  const hash = await bcrypt.hash('oldpass', 1);
+  const token = 'tok456';
+  const hashed = crypto.createHash('sha256').update(token).digest('hex');
+  const future = new Date(Date.now() + 3600000);
+  await pool.query('insert into public.users(id, username, password_hash, provider, password_reset_token, password_reset_expires) values ($1,$2,$3,$4,$5,$6)', [id, 'carol', hash, 'local', hashed, future]);
+
+  await request(app).post('/auth/local/reset').send({ token, password: 'brandnewpass' }).expect(200);
+
+  const { rows } = await pool.query('select password_hash, password_reset_token, password_reset_expires from public.users where id=$1', [id]);
+  expect(await bcrypt.compare('brandnewpass', rows[0].password_hash)).toBe(true);
+  expect(rows[0].password_reset_token).toBeNull();
+  expect(rows[0].password_reset_expires).toBeNull();
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "hr",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "connect-pg-simple": "^9.0.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "express-session": "^1.17.3",
+    "nodemailer": "^6.9.11",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
+    "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "pg-mem": "^3.0.5",
+    "supertest": "^6.3.4"
+  }
+}

--- a/public/forgot.html
+++ b/public/forgot.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head><title>Forgot Password</title></head>
+<body>
+<h1>Forgot Password</h1>
+<form id="forgotForm">
+  <input type="text" id="identifier" placeholder="Username or email" required>
+  <button type="submit">Send Reset Link</button>
+</form>
+<div id="msg"></div>
+<script>
+  document.getElementById('forgotForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const identifier = document.getElementById('identifier').value;
+    await fetch('/auth/local/forgot', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identifier })
+    });
+    document.getElementById('msg').innerText = 'If that account exists, a reset link has been sent.';
+  });
+</script>
+</body>
+</html>

--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>Orientation</title></head>
+<body>
+<h1>Orientation</h1>
+<a href="/forgot.html">Forgot Password</a>
+</body>
+</html>

--- a/public/reset.html
+++ b/public/reset.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head><title>Reset Password</title></head>
+<body>
+<h1>Reset Password</h1>
+<form id="resetForm">
+  <input type="password" id="password" placeholder="New password" required>
+  <input type="hidden" id="token">
+  <button type="submit">Reset Password</button>
+</form>
+<div id="msg"></div>
+<script>
+  const params = new URLSearchParams(location.search);
+  document.getElementById('token').value = params.get('token') || '';
+  document.getElementById('resetForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const password = document.getElementById('password').value;
+    const token = document.getElementById('token').value;
+    const res = await fetch('/auth/local/reset', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, password })
+    });
+    document.getElementById('msg').innerText = res.ok ? 'Password updated' : 'Reset failed';
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend user table with password reset token + expiry
- add endpoints for requesting and applying password resets
- add static forms and integration tests for password reset

## Testing
- `npm install` *(fails: 403 Forbidden - bcrypt)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c367eea350832cb7858b0e7916419e