### PR TITLE
Add password reset link to orientation landing page

### DIFF
--- a/orientation_index.html
+++ b/orientation_index.html
@@ -129,6 +129,7 @@ function AuthPanel({ onAuthed }){
         <button className="btn btn-ghost w-full mt-2" onClick={()=> setMode(m => m==='login'?'register':'login')}>
           {mode === 'login' ? 'Need an account? Register' : 'Already have an account? Sign in'}
         </button>
+        <a href="/reset.html" className="btn btn-ghost w-full mt-2">Reset Password</a>
         <div className="h-px bg-slate-200 my-4"></div>
         <button className="btn btn-outline w-full" onClick={doGoogle}>Continue with Google</button>
       </div>


### PR DESCRIPTION
## Summary
- add Reset Password link after register/sign-in toggle on landing page so users can recover credentials easily

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68c36e78f7c4832cbdda845b9af07bfa