### PR TITLE
Add program and template API helpers

### DIFF
--- a/orientation_index.html
+++ b/orientation_index.html
@@ -173,6 +173,79 @@ async function apiPatchPrefs(data){
   return r.json();
 }
 
+/* ---- Program & Template helpers ---- */
+async function apiListPrograms(){
+  const r = await fetch(`${API}/programs`, { credentials:'include' });
+  if(!r.ok) throw new Error('GET /programs failed');
+  return r.json();
+}
+async function apiCreateProgram(data){
+  const r = await fetch(`${API}/programs`, {
+    method:'POST', credentials:'include',
+    headers:{ 'Content-Type':'application/json' },
+    body: JSON.stringify(data)
+  });
+  if(!r.ok) throw new Error('POST /programs failed');
+  return r.json();
+}
+async function apiPatchProgram(programId, data){
+  const r = await fetch(`${API}/programs/${encodeURIComponent(programId)}`, {
+    method:'PATCH', credentials:'include',
+    headers:{ 'Content-Type':'application/json' },
+    body: JSON.stringify(data)
+  });
+  if(r.status === 404) return null;
+  if(!r.ok) throw new Error(`PATCH /programs/${programId} failed (${r.status})`);
+  return r.json();
+}
+async function apiDeleteProgram(programId){
+  const r = await fetch(`${API}/programs/${encodeURIComponent(programId)}`, {
+    method:'DELETE', credentials:'include'
+  });
+  if(r.status === 404) return null;
+  if(!r.ok) throw new Error(`DELETE /programs/${programId} failed (${r.status})`);
+  return r.json();
+}
+async function apiListTemplates(programId){
+  const r = await fetch(`${API}/programs/${encodeURIComponent(programId)}/templates`, { credentials:'include' });
+  if(!r.ok) throw new Error('GET /programs/:id/templates failed');
+  return r.json();
+}
+async function apiCreateTemplate(programId, data){
+  const r = await fetch(`${API}/programs/${encodeURIComponent(programId)}/templates`, {
+    method:'POST', credentials:'include',
+    headers:{ 'Content-Type':'application/json' },
+    body: JSON.stringify(data)
+  });
+  if(!r.ok) throw new Error('POST /programs/:id/templates failed');
+  return r.json();
+}
+async function apiPatchTemplate(programId, templateId, data){
+  const r = await fetch(`${API}/programs/${encodeURIComponent(programId)}/templates/${encodeURIComponent(templateId)}`, {
+    method:'PATCH', credentials:'include',
+    headers:{ 'Content-Type':'application/json' },
+    body: JSON.stringify(data)
+  });
+  if(r.status === 404) return null;
+  if(!r.ok) throw new Error(`PATCH /programs/${programId}/templates/${templateId} failed (${r.status})`);
+  return r.json();
+}
+async function apiDeleteTemplate(programId, templateId){
+  const r = await fetch(`${API}/programs/${encodeURIComponent(programId)}/templates/${encodeURIComponent(templateId)}`, {
+    method:'DELETE', credentials:'include'
+  });
+  if(r.status === 404) return null;
+  if(!r.ok) throw new Error(`DELETE /programs/${programId}/templates/${templateId} failed (${r.status})`);
+  return r.json();
+}
+async function apiInstantiateProgram(programId) {
+  const res = await fetch(`${API}/programs/${encodeURIComponent(programId)}/instantiate`, {
+    method: 'POST', credentials:'include'
+  });
+  if (!res.ok) throw new Error('POST /programs/:id/instantiate failed');
+  return res.json();
+}
+
 /* ---- TASK helpers ---- */
 async function apiGetTasks(params = {}){
   const usp = new URLSearchParams(params);
@@ -208,14 +281,6 @@ async function apiDeleteTask(taskId) {
   });
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`DELETE /tasks/${taskId} failed (${res.status})`);
-  return res.json();
-}
-
-async function apiInstantiateProgram(programId) {
-  const res = await fetch(`${API}/programs/${encodeURIComponent(programId)}/instantiate`, {
-    method: 'POST', credentials:'include'
-  });
-  if (!res.ok) throw new Error('POST /programs/:id/instantiate failed');
   return res.json();
 }
 


### PR DESCRIPTION
## Summary
- add API helpers to manage programs and templates using fetch with credentials

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_68c379edb7b4832cac7ad4fe91126c17