### PR TITLE
feat: manage program templates

### DIFF
--- a/__tests__/programRoutes.test.js
+++ b/__tests__/programRoutes.test.js
@@ -5,8 +5,8 @@ const { newDb } = require('pg-mem');
 
 // Mock pg to use pg-mem
 const db = newDb();
-const { Pool } = db.adapters.createPg();
-jest.mock('pg', () => ({ Pool }));
+const { Pool: MockPool } = db.adapters.createPg();
+jest.mock('pg', () => ({ Pool: MockPool }));
 
 // Require app after mocks
 const { app, pool } = require('../orientation_server.js');
@@ -56,11 +56,11 @@ describe('program routes', () => {
 
   test('patch updates program fields', async () => {
     const userId = crypto.randomUUID();
-    const hash = await bcrypt.hash('pass', 1);
-    await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [userId, 'u1', hash, 'local']);
+    const hash = await bcrypt.hash('passpass', 1);
+    await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [userId, 'user1', hash, 'local']);
 
     const agent = request.agent(app);
-    await agent.post('/auth/local/login').send({ username: 'u1', password: 'pass' }).expect(200);
+    await agent.post('/auth/local/login').send({ username: 'user1', password: 'passpass' }).expect(200);
 
     const progId = 'prog1';
     await pool.query('insert into public.programs(program_id, title, total_weeks, description, created_by) values ($1,$2,$3,$4,$5)', [progId, 'Old', 4, 'desc', userId]);
@@ -76,11 +76,11 @@ describe('program routes', () => {
 
   test('delete removes program and templates', async () => {
     const userId = crypto.randomUUID();
-    const hash = await bcrypt.hash('pass', 1);
-    await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [userId, 'u2', hash, 'local']);
+    const hash = await bcrypt.hash('passpass', 1);
+    await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [userId, 'user2', hash, 'local']);
 
     const agent = request.agent(app);
-    await agent.post('/auth/local/login').send({ username: 'u2', password: 'pass' }).expect(200);
+    await agent.post('/auth/local/login').send({ username: 'user2', password: 'passpass' }).expect(200);
 
     const progId = 'prog2';
     await pool.query('insert into public.programs(program_id, title, created_by) values ($1,$2,$3)', [progId, 'TBD', userId]);
@@ -97,11 +97,11 @@ describe('program routes', () => {
 
 test('patch updates template fields', async () => {
   const userId = crypto.randomUUID();
-  const hash = await bcrypt.hash('pass', 1);
-  await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [userId, 'u3', hash, 'local']);
+  const hash = await bcrypt.hash('passpass', 1);
+  await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [userId, 'user3', hash, 'local']);
 
   const agent = request.agent(app);
-  await agent.post('/auth/local/login').send({ username: 'u3', password: 'pass' }).expect(200);
+  await agent.post('/auth/local/login').send({ username: 'user3', password: 'passpass' }).expect(200);
 
   const progId = 'prog3';
   await pool.query('insert into public.programs(program_id, title, created_by) values ($1,$2,$3)', [progId, 'title', userId]);
@@ -124,11 +124,11 @@ test('patch updates template fields', async () => {
 
 test('delete removes template row', async () => {
   const userId = crypto.randomUUID();
-  const hash = await bcrypt.hash('pass', 1);
-  await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [userId, 'u4', hash, 'local']);
+  const hash = await bcrypt.hash('passpass', 1);
+  await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [userId, 'user4', hash, 'local']);
 
   const agent = request.agent(app);
-  await agent.post('/auth/local/login').send({ username: 'u4', password: 'pass' }).expect(200);
+  await agent.post('/auth/local/login').send({ username: 'user4', password: 'passpass' }).expect(200);
 
   const progId = 'prog4';
   await pool.query('insert into public.programs(program_id, title, created_by) values ($1,$2,$3)', [progId, 'title', userId]);

--- a/orientation_index.html
+++ b/orientation_index.html
@@ -630,6 +630,7 @@ function App({ me, onSignOut }){
     const [title, setTitle] = useState(program?.title || '');
     const [weeksCount, setWeeksCount] = useState(program?.total_weeks || 6);
     const [desc, setDesc] = useState(program?.description || '');
+    const [showTemplates, setShowTemplates] = useState(false);
 
     useEffect(()=>{
       setTitle(program?.title || '');
@@ -688,12 +689,138 @@ function App({ me, onSignOut }){
               <textarea className="textarea" value={desc} onChange={e=> setDesc(e.target.value)} />
             </div>
             <div className="flex items-center justify-between pt-2">
-              {program?.program_id && <button className="btn btn-outline" onClick={handleDelete}>Delete</button>}
+              {program?.program_id && (
+                <div className="flex items-center gap-2">
+                  <button className="btn btn-outline" onClick={handleDelete}>Delete</button>
+                  <button className="btn btn-outline" onClick={()=> setShowTemplates(true)}>Templates</button>
+                </div>
+              )}
               <div className="ml-auto flex items-center gap-2">
                 <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
                 <button className="btn btn-primary" onClick={handleSave}>Save</button>
               </div>
             </div>
+          </div>
+          {showTemplates && program?.program_id && <TemplateModal programId={program.program_id} onClose={()=> setShowTemplates(false)} />}
+        </div>
+      </div>,
+      document.body
+    );
+  }
+
+  function TemplateModal({ programId, onClose }){
+    const [templates, setTemplates] = useState([]);
+    const [editing, setEditing] = useState(null);
+    const [wk, setWk] = useState(1);
+    const [label, setLabel] = useState('');
+    const [notes, setNotes] = useState('');
+    const [sort, setSort] = useState(1);
+
+    useEffect(()=>{ refresh(); }, [programId]);
+
+    async function refresh(){
+      try {
+        const list = await apiListTemplates(programId);
+        setTemplates(list);
+      } catch(err){
+        console.error('Failed to load templates', err);
+      }
+    }
+
+    function startNew(){
+      setEditing({});
+      setWk(1); setLabel(''); setNotes(''); setSort(1);
+    }
+    function startEdit(t){
+      setEditing(t);
+      setWk(t.week_number||1); setLabel(t.label||''); setNotes(t.notes||''); setSort(t.sort_order||1);
+    }
+    function cancelEdit(){
+      setEditing(null);
+    }
+
+    async function handleSave(e){
+      e.preventDefault();
+      try {
+        const data = { week_number:Number(wk), label:label.trim(), notes, sort_order:Number(sort) };
+        if(editing?.template_id){
+          await apiPatchTemplate(programId, editing.template_id, data);
+        } else {
+          await apiCreateTemplate(programId, data);
+        }
+        await refresh();
+        setEditing(null);
+        if(programId === QS_PROGRAM_ID) await refreshPrograms();
+      } catch(err){
+        console.error('Failed to save template', err);
+        alert('Failed to save template');
+      }
+    }
+
+    async function handleDelete(id){
+      if(!confirm('Delete this template?')) return;
+      try {
+        await apiDeleteTemplate(programId, id);
+        await refresh();
+        if(programId === QS_PROGRAM_ID) await refreshPrograms();
+      } catch(err){
+        console.error('Failed to delete template', err);
+        alert('Failed to delete template');
+      }
+    }
+
+    return ReactDOM.createPortal(
+      <div className="fm-modal-overlay" role="dialog" aria-modal="true" onClick={onClose}>
+        <div className="fm-modal max-w-2xl" onClick={e=> e.stopPropagation()}>
+          <div className="fm-modal-header">
+            <div className="font-semibold">Manage Templates</div>
+            <button className="btn btn-ghost" onClick={onClose} aria-label="Close">✕</button>
+          </div>
+          <div className="fm-modal-body space-y-4">
+            <div className="flex justify-between items-center">
+              <div className="font-semibold">Templates</div>
+              <button className="btn btn-outline" onClick={startNew}>+ New Row</button>
+            </div>
+            <div className="space-y-2">
+              {templates.map(t=> (
+                <div key={t.template_id} className="border rounded p-2 flex items-center justify-between">
+                  <div>
+                    <div className="font-medium">Week {t.week_number} • {t.label}</div>
+                    <div className="text-xs text-slate-500">Sort {t.sort_order}{t.notes?` • ${t.notes}`:''}</div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button className="btn btn-ghost text-xs" onClick={()=> startEdit(t)}>Edit</button>
+                    <button className="btn btn-ghost text-xs" onClick={()=> handleDelete(t.template_id)}>Delete</button>
+                  </div>
+                </div>
+              ))}
+            </div>
+            {editing && (
+              <form onSubmit={handleSave} className="space-y-2 pt-2">
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="text-sm block mb-1">Week #</label>
+                    <input type="number" className="input" value={wk} onChange={e=> setWk(e.target.value)} />
+                  </div>
+                  <div>
+                    <label className="text-sm block mb-1">Sort Order</label>
+                    <input type="number" className="input" value={sort} onChange={e=> setSort(e.target.value)} />
+                  </div>
+                </div>
+                <div>
+                  <label className="text-sm block mb-1">Label</label>
+                  <input className="input" value={label} onChange={e=> setLabel(e.target.value)} />
+                </div>
+                <div>
+                  <label className="text-sm block mb-1">Notes</label>
+                  <textarea className="textarea" value={notes} onChange={e=> setNotes(e.target.value)} />
+                </div>
+                <div className="flex items-center justify-end gap-2">
+                  <button type="button" className="btn btn-ghost" onClick={cancelEdit}>Cancel</button>
+                  <button type="submit" className="btn btn-primary">Save</button>
+                </div>
+              </form>
+            )}
           </div>
         </div>
       </div>,


### PR DESCRIPTION
## Summary
- allow managing templates from Program Manager modal
- support adding, editing, and deleting template rows
- refresh tasks after template updates and update test mocks

## Testing
- `npm test` *(fails: Internal Server Error during programRoutes tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c37ba922b4832c8d819c05d3c4af11