### PR TITLE
Add toggleable side panel to orientation app

### DIFF
--- a/orientation_index.html
+++ b/orientation_index.html
@@ -328,6 +328,7 @@ function App({ me, onSignOut }){
   const [needsInstantiate, setNeedsInstantiate] = useState(false);
   const [programs, setPrograms] = useState([]);
   const [programModal, setProgramModal] = useState({ show:false, program:null });
+  const [panelOpen, setPanelOpen] = useState(false);
   const touchHover = useRef(null);
 
   function buildWeeks(rows){
@@ -852,17 +853,21 @@ function App({ me, onSignOut }){
   );
 
   return (
-    <div className="space-y-6 py-6">
-      <header className="flex items-center justify-between gap-4 flex-wrap">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">ANX Orientation • {trainee}</h1>
-          <p className="text-sm text-slate-500">{numWeeks}-Week Program • Start {fmt(startDate)}</p>
-        </div>
-        <div className="flex items-center gap-2">
-          {controlBar}
-          <button className="btn btn-outline ml-2" onClick={onSignOut}>Sign out</button>
-        </div>
-      </header>
+    <div className="flex">
+      <div className="flex-1 space-y-6 py-6">
+        <header className="flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-2">
+            <button className="btn btn-ghost" onClick={()=> setPanelOpen(o=>!o)} aria-label="Toggle panel">☰</button>
+            <div>
+              <h1 className="text-2xl md:text-3xl font-bold">ANX Orientation • {trainee}</h1>
+              <p className="text-sm text-slate-500">{numWeeks}-Week Program • Start {fmt(startDate)}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {controlBar}
+            <button className="btn btn-outline ml-2" onClick={onSignOut}>Sign out</button>
+          </div>
+        </header>
 
       {needsInstantiate && (
         <div className="card p-6">
@@ -968,6 +973,10 @@ function App({ me, onSignOut }){
         </div>
       </Section>
     </div>
+    {panelOpen && (
+      <aside className="card bg-slate-50 w-64 p-4">{/* Panel content */}</aside>
+    )}
+  </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add `panelOpen` state and hamburger toggle button
- wrap orientation app in flex layout with optional side panel

## Testing
- `npm test` *(fails: program routes tests return 500 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c38dbdf2d8832c804908eec925f02b