### PR TITLE
Add account management and password change forms

### DIFF
--- a/__tests__/accountRoutes.test.js
+++ b/__tests__/accountRoutes.test.js
@@ -1,0 +1,76 @@
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+const crypto = require('crypto');
+const { newDb } = require('pg-mem');
+
+// Mock pg to use pg-mem
+const db = newDb();
+const { Pool: MockPool } = db.adapters.createPg();
+db.public.registerFunction({
+  name: 'to_timestamp',
+  args: ['text'],
+  returns: 'timestamptz',
+  implementation: x => new Date(Number(x) * 1000)
+});
+jest.mock('pg', () => ({ Pool: MockPool }));
+
+// Require app after mocks
+const { app, pool } = require('../orientation_server.js');
+
+describe('account routes', () => {
+  beforeAll(async () => {
+    await pool.query(`
+      create table public.users (
+        id uuid primary key,
+        username text unique,
+        email text,
+        full_name text,
+        password_hash text,
+        provider text,
+        last_login_at timestamptz,
+        updated_at timestamptz
+      );
+      create table public.session (
+        sid text primary key,
+        sess text not null,
+        expire timestamptz not null
+      );
+    `);
+  });
+
+  afterEach(async () => {
+    await pool.query('delete from public.session');
+    await pool.query('delete from public.users');
+  });
+
+  test('patch /me updates account fields', async () => {
+    const id = crypto.randomUUID();
+    const hash = await bcrypt.hash('passpass', 1);
+    await pool.query('insert into public.users(id, username, email, full_name, password_hash, provider) values ($1,$2,$3,$4,$5,$6)', [id, 'user1', 'u1@example.com', 'User One', hash, 'local']);
+
+    const agent = request.agent(app);
+    await agent.post('/auth/local/login').send({ username: 'user1', password: 'passpass' }).expect(200);
+
+    const res = await agent.patch('/me').send({ full_name: 'User 1', email: 'new@example.com', username: 'user1a' }).expect(200);
+    expect(res.body.name).toBe('User 1');
+    expect(res.body.email).toBe('new@example.com');
+    expect(res.body.username).toBe('user1a');
+
+    const { rows } = await pool.query('select full_name, email, username from public.users where id=$1', [id]);
+    expect(rows[0]).toEqual({ full_name: 'User 1', email: 'new@example.com', username: 'user1a' });
+  });
+
+  test('change password updates hash', async () => {
+    const id = crypto.randomUUID();
+    const hash = await bcrypt.hash('oldpass1', 1);
+    await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [id, 'user2', hash, 'local']);
+
+    const agent = request.agent(app);
+    await agent.post('/auth/local/login').send({ username: 'user2', password: 'oldpass1' }).expect(200);
+
+    await agent.post('/auth/local/change-password').send({ current_password: 'oldpass1', new_password: 'newpass123' }).expect(200);
+
+    const { rows } = await pool.query('select password_hash from public.users where id=$1', [id]);
+    expect(await bcrypt.compare('newpass123', rows[0].password_hash)).toBe(true);
+  });
+});

--- a/__tests__/programRoutes.test.js
+++ b/__tests__/programRoutes.test.js
@@ -6,6 +6,12 @@ const { newDb } = require('pg-mem');
 // Mock pg to use pg-mem
 const db = newDb();
 const { Pool: MockPool } = db.adapters.createPg();
+db.public.registerFunction({
+  name: 'to_timestamp',
+  args: ['text'],
+  returns: 'timestamptz',
+  implementation: x => new Date(Number(x) * 1000)
+});
 jest.mock('pg', () => ({ Pool: MockPool }));
 
 // Require app after mocks
@@ -25,8 +31,8 @@ describe('program routes', () => {
       );
       create table public.session (
         sid text primary key,
-        sess jsonb not null,
-        expire timestamp(6) not null
+        sess text not null,
+        expire timestamptz not null
       );
       create table public.programs (
         program_id text primary key,

--- a/orientation_index.html
+++ b/orientation_index.html
@@ -333,6 +333,14 @@ function App({ me, onSignOut }){
   const [templateProgramId, setTemplateProgramId] = useState(null);
   const touchHover = useRef(null);
 
+  const [acctName, setAcctName] = useState(me?.name || '');
+  const [acctEmail, setAcctEmail] = useState(me?.email || '');
+  const [acctUsername, setAcctUsername] = useState(me?.username || '');
+  const [pwCurrent, setPwCurrent] = useState('');
+  const [pwNew, setPwNew] = useState('');
+  const [acctMsg, setAcctMsg] = useState('');
+  const [pwMsg, setPwMsg] = useState('');
+
   function buildWeeks(rows){
     const byWeek = {};
     rows.forEach(r => {
@@ -447,6 +455,46 @@ function App({ me, onSignOut }){
       }
     } catch(err){
       console.error('Failed to refresh programs', err);
+    }
+  }
+
+  async function saveAccount(e){
+    e.preventDefault();
+    setAcctMsg('');
+    try {
+      const r = await fetch(`${API}/me`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ full_name: acctName, email: acctEmail, username: acctUsername })
+      });
+      if (!r.ok) { setAcctMsg('Save failed'); return; }
+      const u = await r.json();
+      setAcctName(u.name || '');
+      setAcctEmail(u.email || '');
+      setAcctUsername(u.username || '');
+      setAcctMsg('Saved');
+    } catch (err) {
+      setAcctMsg('Save failed');
+    }
+  }
+
+  async function changePassword(e){
+    e.preventDefault();
+    setPwMsg('');
+    try {
+      const r = await fetch(`${API}/auth/local/change-password`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ current_password: pwCurrent, new_password: pwNew })
+      });
+      if (!r.ok) { setPwMsg('Change failed'); return; }
+      setPwMsg('Password updated');
+      setPwCurrent('');
+      setPwNew('');
+    } catch (err) {
+      setPwMsg('Change failed');
     }
   }
 
@@ -978,6 +1026,40 @@ function App({ me, onSignOut }){
     {panelOpen && (
       <aside className="card bg-slate-50 w-64 p-4 space-y-4">
         <div>
+          <h3 className="text-sm font-semibold mb-2">Account</h3>
+          <form className="space-y-2" onSubmit={saveAccount}>
+            <div>
+              <label htmlFor="acct_fullname" className="text-sm block mb-1">Full name</label>
+              <input id="acct_fullname" className="input" value={acctName} onChange={e=> setAcctName(e.target.value)} />
+            </div>
+            <div>
+              <label htmlFor="acct_email" className="text-sm block mb-1">Email</label>
+              <input id="acct_email" className="input" value={acctEmail} onChange={e=> setAcctEmail(e.target.value)} />
+            </div>
+            <div>
+              <label htmlFor="acct_username" className="text-sm block mb-1">Username</label>
+              <input id="acct_username" className="input" value={acctUsername} onChange={e=> setAcctUsername(e.target.value)} />
+            </div>
+            {acctMsg && <div className="text-xs text-slate-500">{acctMsg}</div>}
+            <button className="btn btn-primary w-full mt-2" type="submit">Save</button>
+          </form>
+        </div>
+        <div className="pt-4 border-t border-slate-200">
+          <h3 className="text-sm font-semibold mb-2">Change Password</h3>
+          <form className="space-y-2" onSubmit={changePassword}>
+            <div>
+              <label htmlFor="pw_current" className="text-sm block mb-1">Current Password</label>
+              <input id="pw_current" type="password" className="input" value={pwCurrent} onChange={e=> setPwCurrent(e.target.value)} />
+            </div>
+            <div>
+              <label htmlFor="pw_new" className="text-sm block mb-1">New Password</label>
+              <input id="pw_new" type="password" className="input" value={pwNew} onChange={e=> setPwNew(e.target.value)} />
+            </div>
+            {pwMsg && <div className="text-xs text-slate-500">{pwMsg}</div>}
+            <button className="btn btn-primary w-full mt-2" type="submit">Change Password</button>
+          </form>
+        </div>
+        <div className="pt-4 border-t border-slate-200">
           <h3 className="text-sm font-semibold mb-2">Settings</h3>
           <div className="space-y-1">
             {programs.map(p => (


### PR DESCRIPTION
## Summary
- Add REST endpoints to update user profile and change password
- Introduce account and password forms in side panel using existing Tailwind styles
- Expand tests for account management and register required pg-mem helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3904574dc832cbe12c6a7dc88afdb