### PR TITLE
feat: support account updates

### DIFF
--- a/__tests__/accountRoutes.test.js
+++ b/__tests__/accountRoutes.test.js
@@ -73,4 +73,32 @@ describe('account routes', () => {
     const { rows } = await pool.query('select password_hash from public.users where id=$1', [id]);
     expect(await bcrypt.compare('newpass123', rows[0].password_hash)).toBe(true);
   });
+
+  test('patch /me rejects duplicate username or email', async () => {
+    const id1 = crypto.randomUUID();
+    const id2 = crypto.randomUUID();
+    const hash = await bcrypt.hash('passpass', 1);
+    await pool.query('insert into public.users(id, username, email, full_name, password_hash, provider) values ($1,$2,$3,$4,$5,$6)', [id1, 'user1', 'u1@example.com', 'User One', hash, 'local']);
+    await pool.query('insert into public.users(id, username, email, full_name, password_hash, provider) values ($1,$2,$3,$4,$5,$6)', [id2, 'user2', 'u2@example.com', 'User Two', hash, 'local']);
+
+    const agent = request.agent(app);
+    await agent.post('/auth/local/login').send({ username: 'user1', password: 'passpass' }).expect(200);
+
+    await agent.patch('/me').send({ username: 'user2' }).expect(409);
+    await agent.patch('/me').send({ email: 'u2@example.com' }).expect(409);
+  });
+
+  test('change password rejects wrong current password', async () => {
+    const id = crypto.randomUUID();
+    const hash = await bcrypt.hash('rightpass', 1);
+    await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [id, 'user3', hash, 'local']);
+
+    const agent = request.agent(app);
+    await agent.post('/auth/local/login').send({ username: 'user3', password: 'rightpass' }).expect(200);
+
+    await agent.post('/auth/local/change-password').send({ current_password: 'wrongpass', new_password: 'newpass123' }).expect(400);
+
+    const { rows } = await pool.query('select password_hash from public.users where id=$1', [id]);
+    expect(await bcrypt.compare('rightpass', rows[0].password_hash)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- add validator for email addresses
- allow updating full name, email, and username with uniqueness checks
- expand account route tests for username conflicts and wrong password

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c392bf7054832c93812c2614d94d5b