### PR TITLE
feat: add responsive settings panel

### DIFF
--- a/orientation_index.html
+++ b/orientation_index.html
@@ -352,6 +352,7 @@ function App({ me, onSignOut }){
   const [showTemplates, setShowTemplates] = useState(false);
   const [templateProgramId, setTemplateProgramId] = useState(null);
   const touchHover = useRef(null);
+  const panelRef = useRef(null);
 
   const [acctName, setAcctName] = useState(me?.name || '');
   const [acctEmail, setAcctEmail] = useState(me?.email || '');
@@ -360,6 +361,43 @@ function App({ me, onSignOut }){
   const [pwNew, setPwNew] = useState('');
   const [acctMsg, setAcctMsg] = useState('');
   const [pwMsg, setPwMsg] = useState('');
+
+  useEffect(() => {
+    if (!panelOpen) return;
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        setPanelOpen(false);
+      } else if (e.key === 'Tab') {
+        const panel = panelRef.current;
+        if (!panel) return;
+        const focusable = panel.querySelectorAll(
+          'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable.length) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKey);
+    const panel = panelRef.current;
+    const focusable = panel?.querySelectorAll(
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+    );
+    focusable && focusable[0] && focusable[0].focus();
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [panelOpen]);
 
   function buildWeeks(rows){
     const byWeek = {};
@@ -914,7 +952,7 @@ function App({ me, onSignOut }){
       <div className="flex-1 space-y-6 py-6">
         <header className="flex items-center justify-between gap-4 flex-wrap">
           <div className="flex items-center gap-2">
-            <button className="btn btn-ghost" onClick={()=> setPanelOpen(o=>!o)} aria-label="Toggle panel">☰</button>
+            <button className="btn btn-ghost md:hidden" onClick={()=> setPanelOpen(o=>!o)} aria-label="Toggle panel">☰</button>
             <div>
               <h1 className="text-2xl md:text-3xl font-bold">ANX Orientation • {trainee}</h1>
               <p className="text-sm text-slate-500">{numWeeks}-Week Program • Start {fmt(startDate)}</p>
@@ -1031,7 +1069,13 @@ function App({ me, onSignOut }){
       </Section>
     </div>
     {panelOpen && (
-      <aside className="card bg-slate-50 w-64 p-4 space-y-4">
+      <div className="fixed inset-0 bg-black/50 md:hidden" onClick={() => setPanelOpen(false)}></div>
+    )}
+    <aside
+      ref={panelRef}
+      className={`card bg-slate-50 w-64 p-4 space-y-4 transform transition-transform duration-300 fixed inset-y-0 right-0 z-50
+                  ${panelOpen ? 'block translate-x-0' : 'hidden translate-x-full'} md:static md:block md:translate-x-0`}
+    >
         <div>
           <h3 className="text-sm font-semibold mb-2">Account</h3>
           <form className="space-y-2" onSubmit={saveAccount}>
@@ -1102,7 +1146,6 @@ function App({ me, onSignOut }){
           </button>
         </div>
       </aside>
-    )}
     {showTemplates && templateProgramId && (
       <TemplateModal
         programId={templateProgramId}


### PR DESCRIPTION
## Summary
- make settings panel responsive with off-canvas overlay on small screens
- allow closing with Esc and trap focus within the panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c39a645750832cba5f0ab9f4f0b69a