### PR TITLE
Add test for restoring soft-deleted task

### DIFF
--- a/__tests__/programRoutes.test.js
+++ b/__tests__/programRoutes.test.js
@@ -190,7 +190,8 @@ test('deleted task can be restored', async () => {
   res = await agent.get('/tasks').expect(200);
   expect(res.body.find(t => t.task_id === taskId)).toBeDefined();
 
-  const progRows = await pool.query('select 1 from public.programs where program_id=$1', [progId]);
-  expect(progRows.rowCount).toBe(1);
+  // program should still be returned by GET /programs
+  res = await agent.get('/programs').expect(200);
+  expect(res.body.find(p => p.program_id === progId)).toBeDefined();
 });
 });


### PR DESCRIPTION
## Summary
- test restoring a soft-deleted task ensures it appears in GET /tasks
- verify restored task's program still exists via GET /programs

## Testing
- `npm test --silent __tests__/programRoutes.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3b05e38f8832cad7ca19e70c61415