### PR TITLE
Move sign-out button to side panel

### DIFF
--- a/orientation_index.html
+++ b/orientation_index.html
@@ -1010,7 +1010,6 @@ function App({ me, onSignOut }){
           </div>
           <div className="flex items-center gap-2">
             {controlBar}
-            <button className="btn btn-outline ml-2" onClick={onSignOut}>Sign out</button>
           </div>
         </header>
 
@@ -1209,6 +1208,9 @@ function App({ me, onSignOut }){
         <div className="space-y-2 pt-4 border-t border-slate-200">
           <button className="btn btn-outline w-full" onClick={() => refreshPrograms()}>
             Refresh Programs
+          </button>
+          <button className="btn btn-outline w-full" onClick={onSignOut}>
+            Sign out
           </button>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- Remove sign-out button from header and keep control bar layout intact
- Add sign-out button below Refresh Programs in side panel for consistent access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3b4a26068832c8fff3e3e513c50aa