### PR TITLE
Add resizable side panel

### DIFF
--- a/orientation_index.html
+++ b/orientation_index.html
@@ -97,6 +97,28 @@ function useFocusTrap(ref, active) {
   }, [ref, active]);
 }
 
+function useLocalStorageState(key, initial) {
+  const [value, setValue] = useState(() => {
+    const stored = localStorage.getItem(key);
+    return stored !== null ? JSON.parse(stored) : initial;
+  });
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [key, value]);
+  return [value, setValue];
+}
+
+function useRafThrottle(fn) {
+  const frame = useRef(null);
+  return (...args) => {
+    if (frame.current) return;
+    frame.current = requestAnimationFrame(() => {
+      fn(...args);
+      frame.current = null;
+    });
+  };
+}
+
 /* ---- AUTH PANEL (Local + Google) ---- */
 function AuthPanel({ onAuthed }){
   const [mode, setMode] = useState('login');
@@ -394,6 +416,7 @@ function App({ me, onSignOut }){
   const [programs, setPrograms] = useState([]);
   const [programModal, setProgramModal] = useState({ show:false, program:null });
   const [panelOpen, setPanelOpen] = useState(false);
+  const [panelWidth, setPanelWidth] = useLocalStorageState('anx_panel_width_px', 260);
   const panelLabel = panelOpen ? 'Close Panel' : 'Open Panel';
   const [showTemplates, setShowTemplates] = useState(false);
   const [templateProgramId, setTemplateProgramId] = useState(null);
@@ -411,6 +434,21 @@ function App({ me, onSignOut }){
       triggerRef.current = e.currentTarget;
       setPanelOpen(true);
     }
+  };
+
+  const resizeMove = useRafThrottle((e) => {
+    const width = Math.max(260, Math.min(400, window.innerWidth - e.clientX));
+    setPanelWidth(width);
+  });
+  const startResize = (e) => {
+    e.preventDefault();
+    const move = (ev) => resizeMove(ev);
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
   };
 
   const [acctName, setAcctName] = useState(me?.name || '');
@@ -1169,21 +1207,27 @@ function App({ me, onSignOut }){
       >
         {panelLabel}
       </button>
-      {panelOpen && (
+        {panelOpen && (
+          <div
+            className="fixed inset-0 bg-black/50 md:hidden overscroll-contain touch-none"
+            onClick={togglePanel}
+          ></div>
+        )}
+        {/* SidePanel: container uses `card`; buttons use `btn`; fields use `input` for consistent styling */}
         <div
-          className="fixed inset-0 bg-black/50 md:hidden overscroll-contain touch-none"
-          onClick={togglePanel}
+          className="hidden md:block fixed inset-y-0 z-50 w-1 cursor-col-resize"
+          style={{ right: panelWidth }}
+          onPointerDown={startResize}
         ></div>
-      )}
-      {/* SidePanel: container uses `card`; buttons use `btn`; fields use `input` for consistent styling */}
-      <aside
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="panel-heading"
-        className={`card bg-slate-50 w-64 p-4 space-y-4 transform transition-transform duration-300 fixed inset-y-0 right-0 z-50
-                    ${panelOpen ? 'translate-x-0' : 'translate-x-full'} md:static md:block md:translate-x-0`}
-      >
+        <aside
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="panel-heading"
+          className={`card bg-slate-50 p-4 space-y-4 transform transition-transform duration-300 fixed inset-y-0 right-0 z-50
+                     ${panelOpen ? 'translate-x-0' : 'translate-x-full'} md:static md:block md:translate-x-0`}
+          style={{ width: panelWidth }}
+        >
           <h2 id="panel-heading" className="sr-only">Side Panel</h2>
         <div>
           <h3 className="text-sm font-semibold mb-2">Account</h3>


### PR DESCRIPTION
## Summary
- Persist panel width using `useLocalStorageState`
- Add draggable handle to resize side panel
- Introduce RAF-throttled handler to limit resize events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3bac2090c832c8370410cdca339be