### PR TITLE
style: enhance side panel transitions

### DIFF
--- a/orientation_index.html
+++ b/orientation_index.html
@@ -1271,13 +1271,11 @@ function App({ me, onSignOut }){
         </div>
       </Section>
     </div>
-      {panelOpen && (
-        <div
-          className="fixed inset-0 bg-black/50 md:hidden overscroll-contain touch-none"
-          onClick={togglePanel}
-          tabIndex={0}
-        ></div>
-      )}
+      <div
+        className={`fixed inset-0 md:hidden overscroll-contain touch-none apple-backdrop apple-ease duration-300 transition-opacity ${panelOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+        onClick={togglePanel}
+        tabIndex={panelOpen ? 0 : -1}
+      ></div>
       <button
         id="side-panel-toggle"
         onClick={togglePanel}
@@ -1297,7 +1295,7 @@ function App({ me, onSignOut }){
           </svg>
         )}
       </button>
-      {/* SidePanel: container uses `card`; buttons use `btn`; fields use `input` for consistent styling */}
+      {/* SidePanel: container uses apple styling classes; buttons use `btn`; fields use `input` for consistent styling */}
       {panelOpen && (
         <div
           className="hidden md:block fixed inset-y-0 z-50 w-1 cursor-col-resize"
@@ -1312,9 +1310,9 @@ function App({ me, onSignOut }){
           role="dialog"
           aria-modal="true"
           aria-labelledby="panel-heading"
-          className={`card bg-slate-50 p-4 space-y-4 transform transition-transform duration-300 fixed inset-y-0 right-0 z-50
-                     ${panelOpen ? 'translate-x-0' : 'translate-x-full'}`}
-          style={{ width: panelWidth }}
+          className={`bg-white dark:bg-slate-800 apple-shadow apple-border p-4 space-y-4 fixed inset-y-0 right-0 z-50 overflow-hidden transform apple-ease transition-transform duration-300 md:transition-[width] md:duration-300 md:translate-x-0
+                     ${panelOpen ? 'translate-x-0' : 'translate-x-full md:w-0'}`}
+          style={{ width: panelOpen ? panelWidth : 0 }}
         >
         <h2 id="panel-heading" className="sr-only">Side Panel</h2>
         <div className="flex items-center gap-3 pb-4 border-b border-slate-200">


### PR DESCRIPTION
## Summary
- smooth slide-over backdrop with `apple-backdrop` and eased transition
- desktop side panel uses `apple-shadow`/`apple-border` and width transition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3e05acdb0832c83e71015b32dd6d5