### PR TITLE
Display specific password reset error codes

### DIFF
--- a/public/reset.html
+++ b/public/reset.html
@@ -29,7 +29,8 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token, password })
       });
-      msgEl.innerText = res.ok ? 'Password updated' : 'Reset failed';
+      const data = await res.json();
+      msgEl.innerText = res.ok ? 'Password updated' : (data.error || 'Reset failed');
     });
   }
 </script>


### PR DESCRIPTION
## Summary
- Parse JSON response from reset endpoint on the reset page
- Show server-provided error codes for failed password reset attempts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c400887f3c832c8d860689144db4e9