### PR TITLE
Add redirect and link for invalid reset token

### DIFF
--- a/public/reset.html
+++ b/public/reset.html
@@ -17,8 +17,9 @@
   const token = params.get('token');
 
   if (!token) {
-    msgEl.innerText = 'Reset link is invalid or expired';
+    msgEl.innerHTML = 'Reset link is invalid or expired. Redirecting to <a href="/forgot.html">request a new link</a>...';
     submitBtn.disabled = true;
+    setTimeout(() => { window.location.href = '/forgot.html'; }, 3000);
   } else {
     document.getElementById('token').value = token;
     form.addEventListener('submit', async (e) => {


### PR DESCRIPTION
## Summary
- Provide link and auto-redirect to request a new reset token

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4497414fc832c941d62afb2664671