### PR TITLE
Enforce permission-based UI visibility in orientation app

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -448,7 +448,7 @@ function App({ me, onSignOut }){
   const touchHover = useRef(null);
   const panelRef = useRef(null);
   const triggerRef = useRef(null);
-  const perms = me?.perms || new Set();
+  const perms = useMemo(() => new Set(me?.perms || []), [me]);
   const hasPerm = (p) => perms.has(p);
   const isTrainee = (me?.roles || []).includes('trainee');
   const restoreFocus = () => {
@@ -1466,7 +1466,7 @@ function App({ me, onSignOut }){
                         <span className="sr-only">Templates</span>
                       </button>
                       )}
-                      {p.created_by === me.id && (
+                      {p.created_by === me.id && !isTrainee && (
                         <details className="relative">
                           <summary className="btn btn-ghost px-2 -mr-2" tabIndex={0}>⋯</summary>
                           <div className="absolute right-0 z-10 mt-1 w-28 bg-white border rounded shadow">
@@ -1477,14 +1477,14 @@ function App({ me, onSignOut }){
                               <span aria-hidden="true">✏️</span>
                               <span>Edit</span>
                             </button>
-                            {hasPerm('program.delete') && (
-                            <button
-                              className="btn btn-ghost w-full justify-start"
-                              onClick={() => handleDeleteProgram(p.program_id)}
-                            >
-                              <span aria-hidden="true">🗑️</span>
-                              <span>Delete</span>
-                            </button>
+                            {hasPerm('program.delete') && !isTrainee && (
+                              <button
+                                className="btn btn-ghost w-full justify-start"
+                                onClick={() => handleDeleteProgram(p.program_id)}
+                              >
+                                <span aria-hidden="true">🗑️</span>
+                                <span>Delete</span>
+                              </button>
                             )}
                           </div>
                         </details>


### PR DESCRIPTION
## Summary
- Ensure user `perms` stored as Set and `roles` preserved when loading session
- Gate program management controls (templates, delete, create) by permissions and hide for trainees
- Centralize permission checks via memoized Set for reliable UI hiding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5ca951d24832c9761566d55702be4