### PR TITLE
Show user roles in header and indicate read-only areas

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -468,6 +468,7 @@ function App({ me, onSignOut }){
   const perms = useMemo(() => new Set(me?.perms || []), [me]);
   const hasPerm = (p) => perms.has(p);
   const isTrainee = (me?.roles || []).includes('trainee');
+  const isReadOnly = (me?.roles || []).some(r => r === 'viewer' || r === 'auditor');
   const restoreFocus = () => {
     triggerRef.current && triggerRef.current.focus();
   };
@@ -1170,8 +1171,14 @@ function App({ me, onSignOut }){
         <option value="">Select program</option>
         {programs.map(p=> <option key={p.program_id} value={p.program_id}>{p.title}</option>)}
       </select>
-      {(hasPerm('program.create') || hasPerm('program.update')) && (
+      {(hasPerm('program.create') || hasPerm('program.update')) ? (
         <button className="btn btn-outline" onClick={()=> setProgramModal({ show: true, program: programs.find(p => p.program_id === QS_PROGRAM_ID) || null })}>Manage</button>
+      ) : isReadOnly && (
+        <button className="btn btn-outline opacity-50 cursor-not-allowed" title="Read-only users cannot manage programs" disabled>
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M10 1a4 4 0 00-4 4v3H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-1V5a4 4 0 00-4-4zm-2 7V5a2 2 0 114 0v3H8z" clipRule="evenodd" />
+          </svg>
+        </button>
       )}
       <div className="h-6 w-px bg-slate-200" />
       <label className="text-sm text-slate-600">Start</label>
@@ -1197,6 +1204,11 @@ function App({ me, onSignOut }){
               <div>
                 <h1 className="text-2xl md:text-3xl font-bold">ANX Orientation • {trainee}</h1>
                 <p className="text-sm text-slate-500">{numWeeks}-Week Program • Start {fmt(startDate)}</p>
+                {me.roles?.length > 0 && (
+                  <div className="text-xs text-slate-500">
+                    Roles: {me.roles.join(', ')}
+                  </div>
+                )}
               </div>
             </div>
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- display current user's roles in the header
- show lock icon for read-only viewers/auditors on Manage control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5dd305b1c832c9deeec77f8c00d00