### PR TITLE
Add admin role manager page with RBAC controls

### DIFF
--- a/__tests__/rbacRoutes.test.js
+++ b/__tests__/rbacRoutes.test.js
@@ -1,0 +1,81 @@
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+const crypto = require('crypto');
+const { newDb } = require('pg-mem');
+
+// Mock pg to use pg-mem
+const db = newDb();
+const { Pool: MockPool } = db.adapters.createPg();
+
+db.public.registerFunction({
+  name: 'to_timestamp',
+  args: ['text'],
+  returns: 'timestamptz',
+  implementation: x => new Date(Number(x) * 1000)
+});
+
+jest.mock('pg', () => ({ Pool: MockPool }));
+
+// Require app after mocks
+const { app, pool } = require('../orientation_server.js');
+
+describe('rbac admin routes', () => {
+  beforeAll(async () => {
+    await pool.query(`
+      create table public.users (
+        id uuid primary key,
+        username text unique,
+        email text,
+        full_name text,
+        password_hash text,
+        provider text,
+        last_login_at timestamptz,
+        updated_at timestamptz
+      );
+      create table public.session (
+        sid text primary key,
+        sess text not null,
+        expire timestamptz not null
+      );
+      create table public.user_roles (
+        user_id uuid,
+        role_key text
+      );
+      create table public.role_permissions (
+        role_key text,
+        perm_key text
+      );
+    `);
+  });
+
+  afterEach(async () => {
+    await pool.query('delete from public.session');
+    await pool.query('delete from public.users');
+    await pool.query('delete from public.user_roles');
+    await pool.query('delete from public.role_permissions');
+  });
+
+  test('admin can list users and update roles; non-admin forbidden', async () => {
+    const adminId = crypto.randomUUID();
+    const userId = crypto.randomUUID();
+    const hash = await bcrypt.hash('passpass', 1);
+    await pool.query('insert into public.users(id, username, full_name, password_hash, provider) values ($1,$2,$3,$4,$5)', [adminId, 'admin', 'Admin', hash, 'local']);
+    await pool.query('insert into public.users(id, username, full_name, password_hash, provider) values ($1,$2,$3,$4,$5)', [userId, 'user', 'User', hash, 'local']);
+    await pool.query('insert into public.user_roles(user_id, role_key) values ($1,$2)', [adminId, 'admin']);
+
+    const adminAgent = request.agent(app);
+    await adminAgent.post('/auth/local/login').send({ username: 'admin', password: 'passpass' }).expect(200);
+
+    const listRes = await adminAgent.get('/rbac/users').expect(200);
+    expect(listRes.body.length).toBe(2);
+
+    await adminAgent.patch(`/rbac/users/${userId}/roles`).send({ roles: ['manager'] }).expect(200);
+    const { rows } = await pool.query('select role_key from public.user_roles where user_id=$1', [userId]);
+    expect(rows.map(r => r.role_key)).toEqual(['manager']);
+
+    const userAgent = request.agent(app);
+    await userAgent.post('/auth/local/login').send({ username: 'user', password: 'passpass' }).expect(200);
+    await userAgent.get('/rbac/users').expect(403);
+    await userAgent.patch(`/rbac/users/${adminId}/roles`).send({ roles: [] }).expect(403);
+  });
+});

--- a/public/admin/role-manager.html
+++ b/public/admin/role-manager.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Role Manager</title>
+  <link rel="stylesheet" href="/style.css" />
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="/src/admin/RoleManager.jsx"></script>
+</body>
+</html>

--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -1405,6 +1405,9 @@ function App({ me, onSignOut }){
           <div className="flex-1 min-w-0">
             <div className="font-medium truncate">{acctName}</div>
             <div className="text-sm text-slate-500 truncate">{acctEmail}</div>
+            {me?.roles?.length > 0 && (
+              <div className="text-xs text-slate-500 truncate">Role: {me.roles.join(', ')}</div>
+            )}
           </div>
           <button
             className="btn btn-ghost text-sm"
@@ -1452,6 +1455,9 @@ function App({ me, onSignOut }){
                   {acctMsg && <div className="text-xs text-slate-500">{acctMsg}</div>}
                   <button className="btn btn-primary w-full mt-2" type="submit">Save</button>
                 </form>
+                {me.roles?.includes('admin') && (
+                  <a href="/admin/role-manager.html" className="btn btn-outline w-full mt-2">Role Manager</a>
+                )}
               </div>
             )}
           </div>

--- a/src/admin/RoleManager.jsx
+++ b/src/admin/RoleManager.jsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useState } from 'react';
+
+// Roles available in the system
+const ALL_ROLES = ['admin', 'manager', 'trainee'];
+
+export default function RoleManager(){
+  const [me, setMe] = useState(null);
+  const [users, setUsers] = useState([]);
+  const [msg, setMsg] = useState('');
+  const [err, setErr] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      const meRes = await fetch('/me');
+      const meData = await meRes.json();
+      setMe(meData);
+      if(!meData.roles?.includes('admin')) return;
+      const res = await fetch('/rbac/users');
+      if(res.ok){
+        const data = await res.json();
+        setUsers(data);
+      }
+    })();
+  }, []);
+
+  if(!me) return <div>Loading…</div>;
+  if(!me.roles?.includes('admin')) return <div className="card p-6">Access denied</div>;
+
+  const toggleRole = (userId, role) => {
+    setUsers(prev => prev.map(u => u.id === userId ? {
+      ...u,
+      roles: u.roles.includes(role) ? u.roles.filter(r => r !== role) : [...u.roles, role]
+    } : u));
+  };
+
+  const handleSave = async () => {
+    setMsg('');
+    setErr('');
+    try {
+      for(const u of users){
+        const resp = await fetch(`/rbac/users/${u.id}/roles`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ roles: u.roles })
+        });
+        if(!resp.ok) throw new Error('Save failed');
+      }
+      setMsg('Saved');
+    } catch (_e){
+      setErr('Save failed');
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Role Manager</h1>
+      <div className="text-sm text-slate-600">
+        Admin: full access. Manager: manage orientation programs and tasks. Trainee: view their own tasks.
+      </div>
+      <table className="w-full border mt-4">
+        <thead>
+          <tr className="text-left border-b">
+            <th className="p-2">Name</th>
+            <th className="p-2">Username</th>
+            {ALL_ROLES.map(r => (
+              <th key={r} className="p-2">{r}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {users.map(u => (
+            <tr key={u.id} className="border-b">
+              <td className="p-2">{u.full_name || ''}</td>
+              <td className="p-2">{u.username || ''}</td>
+              {ALL_ROLES.map(r => (
+                <td key={r} className="p-2 text-center">
+                  <input
+                    type="checkbox"
+                    checked={u.roles.includes(r)}
+                    onChange={() => toggleRole(u.id, r)}
+                  />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {msg && <div className="text-sm text-green-600">{msg}</div>}
+      {err && <div className="text-sm text-red-600">{err}</div>}
+      <button className="btn btn-primary" onClick={handleSave}>Save</button>
+    </div>
+  );
+}
+
+// Mount automatically when loaded directly
+if (typeof document !== 'undefined') {
+  const rootEl = document.getElementById('root');
+  if (rootEl) {
+    const root = ReactDOM.createRoot(rootEl);
+    root.render(<RoleManager/>);
+  }
+}


### PR DESCRIPTION
## Summary
- Create RoleManager admin page to fetch and edit user roles with inline role descriptions
- Link Role Manager from account menu for admins and serve admin page assets
- Add RBAC API endpoints and tests covering role listing and updates
- Display current user's roles under their email in the account panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5dfd2a034832cb0e0da7b0b73447c