### PR TITLE
Seed initial admin account

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ Escape key is pressed. On larger screens it remains visible.
 
 The panel container uses the shared `card` class, while its buttons and form fields use the
 common `btn` and `input` classes to keep styling consistent across the app.
+
+## Migrations
+
+Run the SQL files in the `migrations/` directory in order. After applying `002_rbac.sql`, run `003_seed_admin.sql`
+to create a default local account (`admin` / `changeme`) and grant it the `admin` role. This ensures at least one
+user can manage roles for others after initial deployment.

--- a/migrations/003_seed_admin.sql
+++ b/migrations/003_seed_admin.sql
@@ -1,0 +1,21 @@
+-- 003_seed_admin.sql
+-- Ensure at least one admin user exists and is assigned the admin role
+
+-- Create an initial admin user if one doesn't already exist
+insert into public.users (username, email, full_name, password_hash, provider)
+values (
+  'admin',
+  'admin@example.com',
+  'Initial Admin',
+  '$2b$12$L76aS1UDRIgja5OpViZubekQpYhDly.eopPsnca2H9xzs46ej9eAq',
+  'local'
+)
+on conflict (username) do nothing;
+
+-- Attach the admin role to the user
+insert into user_roles (user_id, role_id)
+select u.id, r.role_id
+from public.users u
+join roles r on r.role_key = 'admin'
+where u.username = 'admin'
+on conflict do nothing;


### PR DESCRIPTION
## Summary
- add migration seeding a default `admin` user and grant `admin` role
- document running migrations, including the new admin seed, during deployment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5ffe68fdc832c9131b2a9b037dc22