### PR TITLE
Use permissions table for role perms

### DIFF
--- a/__tests__/localAuthFlow.test.js
+++ b/__tests__/localAuthFlow.test.js
@@ -47,13 +47,17 @@ describe('local auth flow', () => {
         role_key text unique,
         description text
       );
+      create table public.permissions (
+        perm_id serial primary key,
+        perm_key text unique
+      );
       create table public.user_roles (
         user_id uuid,
         role_id int references public.roles(role_id)
       );
       create table public.role_permissions (
         role_id int references public.roles(role_id),
-        perm_key text
+        perm_id int references public.permissions(perm_id)
       );
       insert into public.roles(role_key) values ('trainee');
     `);
@@ -63,6 +67,8 @@ describe('local auth flow', () => {
     await pool.query('delete from public.session');
     await pool.query('delete from public.users');
     await pool.query('delete from public.user_roles');
+    await pool.query('delete from public.role_permissions');
+    await pool.query('delete from public.permissions');
   });
 
   test('register, update profile, change password, login with new password', async () => {

--- a/__tests__/prefsRoutesAuth.test.js
+++ b/__tests__/prefsRoutesAuth.test.js
@@ -43,13 +43,17 @@ describe('preferences routes authorization', () => {
         role_key text unique,
         description text
       );
+      create table public.permissions (
+        perm_id serial primary key,
+        perm_key text unique
+      );
       create table public.user_roles (
         user_id uuid,
         role_id int references public.roles(role_id)
       );
       create table public.role_permissions (
         role_id int references public.roles(role_id),
-        perm_key text
+        perm_id int references public.permissions(perm_id)
       );
       create table public.program_memberships (
         user_id uuid,
@@ -73,6 +77,7 @@ describe('preferences routes authorization', () => {
     await pool.query('delete from public.program_memberships');
     await pool.query('delete from public.user_roles');
     await pool.query('delete from public.role_permissions');
+    await pool.query('delete from public.permissions');
     await pool.query('delete from public.session');
     await pool.query('delete from public.users');
   });

--- a/__tests__/programRoutes.test.js
+++ b/__tests__/programRoutes.test.js
@@ -39,6 +39,10 @@ describe('program routes', () => {
         role_key text unique,
         description text
       );
+      create table public.permissions (
+        perm_id serial primary key,
+        perm_key text unique
+      );
       create table public.programs (
         program_id text primary key,
         title text not null,
@@ -61,7 +65,7 @@ describe('program routes', () => {
       );
       create table public.role_permissions (
         role_id int references public.roles(role_id),
-        perm_key text
+        perm_id int references public.permissions(perm_id)
       );
       create table public.orientation_tasks (
         task_id uuid primary key,
@@ -85,6 +89,7 @@ describe('program routes', () => {
     await pool.query('delete from public.programs');
     await pool.query('delete from public.user_roles');
     await pool.query('delete from public.role_permissions');
+    await pool.query('delete from public.permissions');
     await pool.query('delete from public.session');
     await pool.query('delete from public.users');
   });

--- a/__tests__/rbacRoutes.test.js
+++ b/__tests__/rbacRoutes.test.js
@@ -42,13 +42,17 @@ describe('rbac admin routes', () => {
         role_key text unique,
         description text
       );
+      create table public.permissions (
+        perm_id serial primary key,
+        perm_key text unique
+      );
       create table public.user_roles (
         user_id uuid,
         role_id int references public.roles(role_id)
       );
       create table public.role_permissions (
         role_id int references public.roles(role_id),
-        perm_key text
+        perm_id int references public.permissions(perm_id)
       );
       insert into public.roles(role_key) values ('admin'),('manager'),('viewer'),('trainee'),('auditor');
     `);
@@ -59,6 +63,7 @@ describe('rbac admin routes', () => {
     await pool.query('delete from public.users');
     await pool.query('delete from public.user_roles');
     await pool.query('delete from public.role_permissions');
+    await pool.query('delete from public.permissions');
   });
 
   test('admin can list users and update roles; non-admin forbidden', async () => {

--- a/__tests__/taskRoutesAuth.test.js
+++ b/__tests__/taskRoutesAuth.test.js
@@ -43,6 +43,10 @@ describe('task routes authorization', () => {
         role_key text unique,
         description text
       );
+      create table public.permissions (
+        perm_id serial primary key,
+        perm_key text unique
+      );
       create table public.orientation_tasks (
         task_id uuid primary key default gen_random_uuid(),
         user_id uuid,
@@ -61,7 +65,7 @@ describe('task routes authorization', () => {
       );
       create table public.role_permissions (
         role_id int references public.roles(role_id),
-        perm_key text
+        perm_id int references public.permissions(perm_id)
       );
       create table public.program_memberships (
         user_id uuid,
@@ -69,6 +73,8 @@ describe('task routes authorization', () => {
         role text
       );
       insert into public.roles(role_key) values ('admin'),('manager'),('viewer'),('trainee'),('auditor');
+      insert into public.permissions(perm_key) values
+        ('task.create'),('task.update'),('task.delete');
     `);
   });
 
@@ -83,12 +89,13 @@ describe('task routes authorization', () => {
 
   test('manager can view tasks for managed program', async () => {
     await pool.query(`
-      insert into public.role_permissions(role_id, perm_key)
-      select r.role_id, rp.perm_key from (values
+      insert into public.role_permissions(role_id, perm_id)
+      select r.role_id, p.perm_id from (values
         ('manager','task.create'),('manager','task.update'),('manager','task.delete'),
         ('trainee','task.create'),('trainee','task.update'),('trainee','task.delete')
       ) as rp(role_key, perm_key)
-      join public.roles r on r.role_key = rp.role_key;
+      join public.roles r on r.role_key = rp.role_key
+      join public.permissions p on p.perm_key = rp.perm_key;
     `);
 
     const managerId = crypto.randomUUID();
@@ -119,12 +126,13 @@ describe('task routes authorization', () => {
 
   test('post tasks requires managing program when assigning to others', async () => {
     await pool.query(`
-      insert into public.role_permissions(role_id, perm_key)
-      select r.role_id, rp.perm_key from (values
+      insert into public.role_permissions(role_id, perm_id)
+      select r.role_id, p.perm_id from (values
         ('manager','task.create'),
         ('trainee','task.create')
       ) as rp(role_key, perm_key)
-      join public.roles r on r.role_key = rp.role_key;
+      join public.roles r on r.role_key = rp.role_key
+      join public.permissions p on p.perm_key = rp.perm_key;
     `);
     const managerId = crypto.randomUUID();
     const traineeId = crypto.randomUUID();
@@ -147,11 +155,12 @@ describe('task routes authorization', () => {
 
   test('patch tasks limits fields by role', async () => {
     await pool.query(`
-      insert into public.role_permissions(role_id, perm_key)
-      select r.role_id, rp.perm_key from (values
+      insert into public.role_permissions(role_id, perm_id)
+      select r.role_id, p.perm_id from (values
         ('manager','task.update'),('trainee','task.update')
       ) as rp(role_key, perm_key)
-      join public.roles r on r.role_key = rp.role_key;
+      join public.roles r on r.role_key = rp.role_key
+      join public.permissions p on p.perm_key = rp.perm_key;
     `);
     const managerId = crypto.randomUUID();
     const traineeId = crypto.randomUUID();
@@ -177,11 +186,12 @@ describe('task routes authorization', () => {
 
   test('delete tasks follows scope rules', async () => {
     await pool.query(`
-      insert into public.role_permissions(role_id, perm_key)
-      select r.role_id, rp.perm_key from (values
+      insert into public.role_permissions(role_id, perm_id)
+      select r.role_id, p.perm_id from (values
         ('manager','task.delete'),('trainee','task.delete')
       ) as rp(role_key, perm_key)
-      join public.roles r on r.role_key = rp.role_key;
+      join public.roles r on r.role_key = rp.role_key
+      join public.permissions p on p.perm_key = rp.perm_key;
     `);
     const managerId = crypto.randomUUID();
     const traineeId = crypto.randomUUID();

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -84,8 +84,12 @@ app.use(async (req, _res, next) => {
       req.roles = roleRows.map(r => r.role_key);
       const roleIds = roleRows.map(r => r.role_id);
       if (roleIds.length) {
-        lastQuery = 'select distinct perm_key from role_permissions where role_id = any($1::int[])';
+        lastQuery = `select distinct p.perm_key
+          from role_permissions rp
+          join permissions p on rp.perm_id = p.perm_id
+          where rp.role_id = any($1::int[])`;
         const { rows: permRows } = await pool.query(lastQuery, [roleIds]);
+        // map from permissions table alias p
         req.perms = new Set(permRows.map(p => p.perm_key));
       } else {
         req.perms = new Set();


### PR DESCRIPTION
## Summary
- Join `permissions` when resolving role permissions and map results
- Update tests to include `permissions` table and seed perms by id

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7b4eb5a60832c8e530d123727e035