### PR TITLE
Restrict user management to admin permission

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -348,8 +348,8 @@ function ensurePerm(...permKeys) {
     if (!req.isAuthenticated?.()) {
       return res.status(401).json({ error: 'auth_required' });
     }
-    // Admins and Managers are allowed through
-    if (req.roles?.includes('admin') || req.roles?.includes('manager')) return next();
+    // Admins are allowed through
+    if (req.roles?.includes('admin')) return next();
     for (const key of permKeys) {
       if (req.perms?.has(key)) return next();
     }
@@ -431,9 +431,8 @@ app.patch('/prefs', ensureAuth, async (req, res) => {
 
 // ==== 7) RBAC admin ====
 
-app.get('/rbac/users', async (req, res) => {
+app.get('/rbac/users', ensurePerm('admin.users.manage'), async (req, res) => {
   try {
-    if (!(req.roles.includes('admin') || req.roles.includes('manager'))) return res.status(403).json({ error: 'forbidden' });
     const sql = `
       select u.id, u.full_name, u.username,
              coalesce(array_agg(r.role_key) filter (where r.role_key is not null), '{}') as roles
@@ -450,9 +449,8 @@ app.get('/rbac/users', async (req, res) => {
   }
 });
 
-app.patch('/rbac/users/:id/roles', async (req, res) => {
+app.patch('/rbac/users/:id/roles', ensurePerm('admin.users.manage'), async (req, res) => {
   try {
-    if (!(req.roles.includes('admin') || req.roles.includes('manager'))) return res.status(403).json({ error: 'forbidden' });
     const { id } = req.params;
     const { roles = [] } = req.body || {};
     if (!Array.isArray(roles)) return res.status(400).json({ error: 'invalid_roles' });


### PR DESCRIPTION
## Summary
- Require `admin.users.manage` permission for listing users or modifying roles
- Limit `ensurePerm` middleware to only auto-allow admins

## Testing
- `npm test` *(fails: relation "permissions" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dc926578832cb35f8565084cb871