### PR TITLE
Restrict permission bypass to admins

### DIFF
--- a/__tests__/accountRoutes.test.js
+++ b/__tests__/accountRoutes.test.js
@@ -48,6 +48,14 @@ describe('account routes', () => {
         role_id int references public.roles(role_id),
         perm_key text
       );
+      create table public.user_preferences (
+        user_id uuid primary key,
+        program_id text,
+        start_date date,
+        num_weeks int,
+        trainee text,
+        updated_at timestamptz
+      );
       insert into public.roles(role_key) values ('admin'),('manager'),('viewer'),('trainee'),('auditor');
     `);
   });
@@ -57,6 +65,7 @@ describe('account routes', () => {
     await pool.query('delete from public.users');
     await pool.query('delete from public.user_roles');
     await pool.query('delete from public.role_permissions');
+    await pool.query('delete from public.user_preferences');
   });
 
   test('get /me returns roles and permissions', async () => {

--- a/__tests__/localAuthFlow.test.js
+++ b/__tests__/localAuthFlow.test.js
@@ -55,6 +55,14 @@ describe('local auth flow', () => {
         role_id int references public.roles(role_id),
         perm_key text
       );
+      create table public.user_preferences (
+        user_id uuid primary key,
+        program_id text,
+        start_date date,
+        num_weeks int,
+        trainee text,
+        updated_at timestamptz
+      );
       insert into public.roles(role_key) values ('trainee');
     `);
   });
@@ -63,6 +71,7 @@ describe('local auth flow', () => {
     await pool.query('delete from public.session');
     await pool.query('delete from public.users');
     await pool.query('delete from public.user_roles');
+    await pool.query('delete from public.user_preferences');
   });
 
   test('register, update profile, change password, login with new password', async () => {

--- a/__tests__/programRoutes.test.js
+++ b/__tests__/programRoutes.test.js
@@ -63,6 +63,14 @@ describe('program routes', () => {
         role_id int references public.roles(role_id),
         perm_key text
       );
+      create table public.user_preferences (
+        user_id uuid primary key,
+        program_id text,
+        start_date date,
+        num_weeks int,
+        trainee text,
+        updated_at timestamptz
+      );
       create table public.orientation_tasks (
         task_id uuid primary key,
         user_id uuid,
@@ -85,6 +93,7 @@ describe('program routes', () => {
     await pool.query('delete from public.programs');
     await pool.query('delete from public.user_roles');
     await pool.query('delete from public.role_permissions');
+    await pool.query('delete from public.user_preferences');
     await pool.query('delete from public.session');
     await pool.query('delete from public.users');
   });

--- a/__tests__/rbacRoutes.test.js
+++ b/__tests__/rbacRoutes.test.js
@@ -50,6 +50,14 @@ describe('rbac admin routes', () => {
         role_id int references public.roles(role_id),
         perm_key text
       );
+      create table public.user_preferences (
+        user_id uuid primary key,
+        program_id text,
+        start_date date,
+        num_weeks int,
+        trainee text,
+        updated_at timestamptz
+      );
       insert into public.roles(role_key) values ('admin'),('manager'),('viewer'),('trainee'),('auditor');
     `);
   });
@@ -59,6 +67,7 @@ describe('rbac admin routes', () => {
     await pool.query('delete from public.users');
     await pool.query('delete from public.user_roles');
     await pool.query('delete from public.role_permissions');
+    await pool.query('delete from public.user_preferences');
   });
 
   test('admin can list users and update roles; non-admin forbidden', async () => {

--- a/__tests__/taskRoutesAuth.test.js
+++ b/__tests__/taskRoutesAuth.test.js
@@ -63,6 +63,14 @@ describe('task routes authorization', () => {
         role_id int references public.roles(role_id),
         perm_key text
       );
+      create table public.user_preferences (
+        user_id uuid primary key,
+        program_id text,
+        start_date date,
+        num_weeks int,
+        trainee text,
+        updated_at timestamptz
+      );
       create table public.program_memberships (
         user_id uuid,
         program_id text,
@@ -77,6 +85,7 @@ describe('task routes authorization', () => {
     await pool.query('delete from public.program_memberships');
     await pool.query('delete from public.user_roles');
     await pool.query('delete from public.role_permissions');
+    await pool.query('delete from public.user_preferences');
     await pool.query('delete from public.session');
     await pool.query('delete from public.users');
   });

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -84,10 +84,8 @@ app.use(async (req, _res, next) => {
       req.roles = roleRows.map(r => r.role_key);
       const roleIds = roleRows.map(r => r.role_id);
       if (roleIds.length) {
-        lastQuery = 'select distinct p.perm_key '
-        + 'from role_permissions rp '
-        + 'join permissions p on p.perm_id = rp.perm_id '
-        + 'where rp.role_id = any($1::int[])';
+        lastQuery = 'select distinct perm_key from role_permissions '
+          + 'where role_id = any($1::int[])';
         const { rows: permRows } = await pool.query(lastQuery, [roleIds]);
         req.perms = new Set(permRows.map(p => p.perm_key));
       } else {
@@ -348,12 +346,18 @@ function ensurePerm(...permKeys) {
     if (!req.isAuthenticated?.()) {
       return res.status(401).json({ error: 'auth_required' });
     }
-    // Admins are allowed through
-    if (req.roles?.includes('admin')) return next();
-    for (const key of permKeys) {
-      if (req.perms?.has(key)) return next();
+
+    // Only admins bypass permission checks entirely
+    if (req.roles?.includes('admin')) {
+      return next();
     }
-    res.status(403).json({ error: 'forbidden' });
+
+    const hasPerm = permKeys.some(key => req.perms?.has(key));
+    if (hasPerm) {
+      return next();
+    }
+
+    return res.status(403).json({ error: 'forbidden' });
   };
 }
 
@@ -410,11 +414,33 @@ app.patch('/me', ensureAuth, async (req, res) => {
 });
 
 app.get('/prefs', ensureAuth, async (req, res) => {
-  const { rows } = await pool.query('select * from public.user_preferences where user_id=$1', [req.user.id]);
+  const targetId = req.query.user_id || req.user.id;
+  if (targetId !== req.user.id) {
+    const isAdmin = req.roles?.includes('admin');
+    let manages = false;
+    if (!isAdmin) {
+      try {
+        const { rows: pref } = await pool.query('select program_id from public.user_preferences where user_id=$1', [targetId]);
+        const prog = pref[0]?.program_id;
+        if (prog) manages = await userManagesProgram(req.user.id, prog);
+      } catch (_e) { /* ignore */ }
+    }
+    if (!(isAdmin || manages)) return res.status(403).json({ error: 'forbidden' });
+  }
+  const { rows } = await pool.query('select * from public.user_preferences where user_id=$1', [targetId]);
   res.json(rows[0] || {});
 });
+
 app.patch('/prefs', ensureAuth, async (req, res) => {
-  const { program_id, start_date, num_weeks, trainee } = req.body || {};
+  const { user_id = req.user.id, program_id, start_date, num_weeks, trainee } = req.body || {};
+  if (user_id !== req.user.id) {
+    const isAdmin = req.roles?.includes('admin');
+    let manages = false;
+    if (!isAdmin && program_id) {
+      try { manages = await userManagesProgram(req.user.id, program_id); } catch (_e) { /* ignore */ }
+    }
+    if (!(isAdmin || manages)) return res.status(403).json({ error: 'forbidden' });
+  }
   const up = `
     insert into public.user_preferences (user_id, program_id, start_date, num_weeks, trainee, updated_at)
     values ($1,$2,$3,$4,$5, now())
@@ -425,7 +451,7 @@ app.patch('/prefs', ensureAuth, async (req, res) => {
         trainee=excluded.trainee,
         updated_at=now()
     returning *;`;
-  const { rows } = await pool.query(up, [req.user.id, program_id, start_date, num_weeks, trainee]);
+  const { rows } = await pool.query(up, [user_id, program_id, start_date, num_weeks, trainee]);
   res.json(rows[0]);
 });
 


### PR DESCRIPTION
## Summary
- Ensure only `admin` role can bypass permission checks
- Load permissions directly from `role_permissions` table
- Allow admins or program managers to manage other users' preferences and add missing test fixtures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7de1e4680832c9fe73f623412d504