### PR TITLE
Restrict manager access in ensurePerm

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -348,8 +348,8 @@ function ensurePerm(...permKeys) {
     if (!req.isAuthenticated?.()) {
       return res.status(401).json({ error: 'auth_required' });
     }
-    // Admins and Managers are allowed through
-    if (req.roles?.includes('admin') || req.roles?.includes('manager')) return next();
+    // Admins are allowed through automatically
+    if (req.roles?.includes('admin')) return next();
     for (const key of permKeys) {
       if (req.perms?.has(key)) return next();
     }


### PR DESCRIPTION
## Summary
- Only allow admins through `ensurePerm` automatically
- Require managers to explicitly hold a permission key

## Testing
- `npm test` *(fails: relation "permissions" does not exist; multiple tests error)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e5731a20832c8f73a46f254a5a28