### PR TITLE
Restrict RBAC user management to admins

### DIFF
--- a/__tests__/rbacRoutes.test.js
+++ b/__tests__/rbacRoutes.test.js
@@ -87,4 +87,19 @@ describe('rbac admin routes', () => {
     await userAgent.get('/rbac/users').expect(403);
     await userAgent.patch(`/rbac/users/${adminId}/roles`).send({ roles: [] }).expect(403);
   });
+
+  test('manager cannot list users or update roles', async () => {
+    const managerId = crypto.randomUUID();
+    const userId = crypto.randomUUID();
+    const hash = await bcrypt.hash('passpass', 1);
+    await pool.query('insert into public.users(id, username, full_name, password_hash, provider) values ($1,$2,$3,$4,$5)', [managerId, 'mgr', 'Manager', hash, 'local']);
+    await pool.query('insert into public.users(id, username, full_name, password_hash, provider) values ($1,$2,$3,$4,$5)', [userId, 'user', 'User', hash, 'local']);
+    await pool.query('insert into public.user_roles(user_id, role_id) select $1, role_id from public.roles where role_key=$2', [managerId, 'manager']);
+
+    const managerAgent = request.agent(app);
+    await managerAgent.post('/auth/local/login').send({ username: 'mgr', password: 'passpass' }).expect(200);
+
+    await managerAgent.get('/rbac/users').expect(403);
+    await managerAgent.patch(`/rbac/users/${userId}/roles`).send({ roles: ['viewer'] }).expect(403);
+  });
 });

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -473,9 +473,8 @@ app.patch('/prefs', ensureAuth, async (req, res) => {
 
 // ==== 7) RBAC admin ====
 
-app.get('/rbac/users', async (req, res) => {
+app.get('/rbac/users', ensurePerm('admin.users.manage'), async (req, res) => {
   try {
-    if (!(req.roles.includes('admin') || req.roles.includes('manager'))) return res.status(403).json({ error: 'forbidden' });
     const sql = `
       select u.id, u.full_name, u.username,
              coalesce(array_agg(r.role_key) filter (where r.role_key is not null), '{}') as roles
@@ -492,9 +491,8 @@ app.get('/rbac/users', async (req, res) => {
   }
 });
 
-app.patch('/rbac/users/:id/roles', async (req, res) => {
+app.patch('/rbac/users/:id/roles', ensurePerm('admin.users.manage'), async (req, res) => {
   try {
-    if (!(req.roles.includes('admin') || req.roles.includes('manager'))) return res.status(403).json({ error: 'forbidden' });
     const { id } = req.params;
     const { roles = [] } = req.body || {};
     if (!Array.isArray(roles)) return res.status(400).json({ error: 'invalid_roles' });


### PR DESCRIPTION
## Summary
- Require `admin.users.manage` permission for `/rbac/users` and `/rbac/users/:id/roles`
- Add regression tests ensuring managers receive HTTP 403 on RBAC user management routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7ede8ba88832c8476523c7b9731cc