### PR TITLE
Allow managers to modify viewer and trainee roles

### DIFF
--- a/src/admin/RoleManager.jsx
+++ b/src/admin/RoleManager.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 // Roles available in the system
-const ALL_ROLES = ['admin', 'manager', 'trainee'];
+const ALL_ROLES = ['admin', 'manager', 'viewer', 'trainee'];
 
 export default function RoleManager(){
   const [me, setMe] = useState(null);
@@ -14,7 +14,7 @@ export default function RoleManager(){
       const meRes = await fetch('/me');
       const meData = await meRes.json();
       setMe(meData);
-      if(!meData.roles?.includes('admin')) return;
+      if(!meData.roles?.some(r => ['admin', 'manager'].includes(r))) return;
       const res = await fetch('/rbac/users');
       if(res.ok){
         const data = await res.json();
@@ -24,9 +24,15 @@ export default function RoleManager(){
   }, []);
 
   if(!me) return <div>Loading…</div>;
-  if(!me.roles?.includes('admin')) return <div className="card p-6">Access denied</div>;
+  if(!me.roles?.some(r => ['admin', 'manager'].includes(r))) return <div className="card p-6">Access denied</div>;
+
+  const isAdmin = me.roles.includes('admin');
+  const isManager = me.roles.includes('manager');
+  const managerOnly = isManager && !isAdmin;
+  const MANAGER_EDITABLE_ROLES = ['viewer', 'trainee'];
 
   const toggleRole = (userId, role) => {
+    if (managerOnly && !MANAGER_EDITABLE_ROLES.includes(role)) return;
     setUsers(prev => prev.map(u => u.id === userId ? {
       ...u,
       roles: u.roles.includes(role) ? u.roles.filter(r => r !== role) : [...u.roles, role]
@@ -38,10 +44,11 @@ export default function RoleManager(){
     setErr('');
     try {
       for(const u of users){
+        const roles = managerOnly ? u.roles.filter(r => MANAGER_EDITABLE_ROLES.includes(r)) : u.roles;
         const resp = await fetch(`/rbac/users/${u.id}/roles`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ roles: u.roles })
+          body: JSON.stringify({ roles })
         });
         if(!resp.ok) throw new Error('Save failed');
       }
@@ -55,7 +62,7 @@ export default function RoleManager(){
     <div className="max-w-4xl mx-auto p-4 space-y-4">
       <h1 className="text-2xl font-bold">Role Manager</h1>
       <div className="text-sm text-slate-600">
-        Admin: full access. Manager: manage orientation programs and tasks. Trainee: view their own tasks.
+        Admin: full access. Manager: manage orientation programs and tasks. Viewer: read-only access. Trainee: view their own tasks.
       </div>
       <table className="w-full border mt-4">
         <thead>
@@ -78,6 +85,7 @@ export default function RoleManager(){
                     type="checkbox"
                     checked={u.roles.includes(r)}
                     onChange={() => toggleRole(u.id, r)}
+                    disabled={managerOnly && !MANAGER_EDITABLE_ROLES.includes(r)}
                   />
                 </td>
               ))}


### PR DESCRIPTION
## Summary
- allow admins and managers to access Role Manager
- add viewer role and restrict managers to editing viewer and trainee roles
- filter role updates so managers only send allowed roles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7f1061f20832cb20154dff2918c59