### PR TITLE
Include viewer role in preferences tests

### DIFF
--- a/__tests__/prefsRoutesAuth.test.js
+++ b/__tests__/prefsRoutesAuth.test.js
@@ -59,7 +59,7 @@ describe('preferences routes', () => {
         trainee text,
         updated_at timestamptz
       );
-      insert into public.roles(role_key) values ('trainee'), ('manager'), ('admin');
+      insert into public.roles(role_key) values ('trainee'), ('manager'), ('viewer'), ('admin');
     `);
   });
 


### PR DESCRIPTION
## Summary
- seed viewer role in preferences route test setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f5b48ca0832cb21907d2e291c701