### PR TITLE
Restrict task deletion to privileged users

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -1399,7 +1399,7 @@ useEffect(() => {
                 <div className="grid md:grid-cols-2 gap-3 mt-4">
                   {(w.tasks||[]).map((t,ti)=> (
                     <div key={t.id} className={`card p-3 relative ${t.completed?'border-emerald-300 bg-emerald-50':''}`}>
-                      {hasPerm('task.delete') && !isTrainee && (
+                      {hasPerm('task.delete') && isPrivileged && !isTrainee && (
                         <button type="button" aria-label="Delete" className="absolute top-1 right-1 text-xs text-slate-500 hover:text-slate-700"
                                 onClick={()=> handleDeleteTask(wi,ti)}>✕</button>
                       )}
@@ -1427,7 +1427,7 @@ useEffect(() => {
           })}
         </div>
       </Section>
-      {!isTrainee && (
+      {hasPerm('task.delete') && isPrivileged && !isTrainee && (
       <Section title="Deleted Tasks">
         <div className="space-y-2">
           {deletedTasks.length ? (


### PR DESCRIPTION
## Summary
- require privileged status alongside `task.delete` permission for task delete actions
- limit deleted-task panel to privileged users with delete permission

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f9229570832ca13f9ce5574d444f