### PR TITLE
Restrict trainee task patch permissions

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -870,15 +870,11 @@ app.patch('/tasks/:id', ensurePerm('task.update'), async (req, res) => {
     let isManager = false;
     try { isManager = await userManagesProgram(req.user.id, task.program_id); } catch (_e) { /* ignore */ }
 
-    let allowed = [];
-    if (isAdmin) allowed = allFields;
-    else if (isTrainee) {
-      if (!owns) return res.status(403).json({ error: 'forbidden' });
+    let allowed;
+    if (isAdmin || isManager) {
+      allowed = allFields;
+    } else if (isTrainee && owns) {
       allowed = ['done'];
-    } else if (isManager) {
-      allowed = allFields;
-    } else if (owns) {
-      allowed = allFields;
     } else {
       return res.status(403).json({ error: 'forbidden' });
     }


### PR DESCRIPTION
## Summary
- restrict task patch updates so only admins and program managers can change all fields while trainees can only toggle their own task completion state

## Testing
- npm test -- --runTestsByPath __tests__/taskRoutesAuth.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c8301cd4e4832cb79e4dc3ed4d5e04