### PR TITLE
Restrict task deletion to admins and managers

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -920,11 +920,12 @@ app.delete('/tasks/:id', ensurePerm('task.delete'), async (req, res) => {
     if (!task) return res.status(404).json({ error: 'Not found' });
 
     const isAdmin = req.roles?.includes('admin');
-    const owns = task.user_id === req.user.id;
     let isManager = false;
-    try { isManager = await userManagesProgram(req.user.id, task.program_id); } catch (_e) { /* ignore */ }
+    if (req.user?.id) {
+      try { isManager = await userManagesProgram(req.user.id, task.program_id); } catch (_e) { /* ignore */ }
+    }
 
-    if (!(isAdmin || isManager || owns)) {
+    if (!(isAdmin || isManager)) {
       return res.status(403).json({ error: 'forbidden' });
     }
 


### PR DESCRIPTION
## Summary
- remove the ownership bypass from task deletion authorization
- only allow task deletion when the requester is an admin or manager and avoid unnecessary permission checks for anonymous users

## Testing
- CI=1 npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c832760de0832c9ce4978aa164f223