### PR TITLE
Allow managers to operate across program tasks

### DIFF
--- a/__tests__/taskRoutesAuth.test.js
+++ b/__tests__/taskRoutesAuth.test.js
@@ -109,7 +109,7 @@ describe('task routes authorization', () => {
     let res = await mgrAgent.get('/tasks?program_id=prog1').expect(200);
     expect(res.body.find(t => t.task_id === task1)).toBeDefined();
     res = await mgrAgent.get('/tasks?program_id=prog2').expect(200);
-    expect(res.body.find(t => t.task_id === task2)).toBeUndefined();
+    expect(res.body.find(t => t.task_id === task2)).toBeDefined();
 
     const traineeAgent = request.agent(app);
     await traineeAgent.post('/auth/local/login').send({ username:'trainee', password:'passpass' }).expect(200);


### PR DESCRIPTION
## Summary
- let admin and manager roles skip program membership checks when viewing, creating, updating, deleting, or instantiating tasks
- avoid unnecessary membership lookups by short-circuiting `userManagesProgram`
- update task authorization test expectations for the expanded manager scope

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c836e4b894832cb1718b835817a359