### PR TITLE
Add task.assign permission and map to roles

### DIFF
--- a/migrations/002_rbac.sql
+++ b/migrations/002_rbac.sql
@@ -121,6 +121,7 @@ insert into permissions(perm_key, description) values
   ('template.delete', 'Delete templates'),
   ('task.create',     'Create tasks'),
   ('task.update',     'Edit tasks'),
+  ('task.assign',     'Assign tasks to dates/users'),
   ('task.delete',     'Delete tasks')
 on conflict do nothing;
 
@@ -138,6 +139,7 @@ select r.role_id, p.perm_key from (
     ('admin',   'template.delete'),
     ('admin',   'task.create'),
     ('admin',   'task.update'),
+    ('admin',   'task.assign'),
     ('admin',   'task.delete'),
     ('manager', 'program.create'),
     ('manager', 'program.read'),
@@ -149,6 +151,7 @@ select r.role_id, p.perm_key from (
     ('manager', 'template.delete'),
     ('manager', 'task.create'),
     ('manager', 'task.update'),
+    ('manager', 'task.assign'),
     ('manager', 'task.delete'),
     ('viewer',  'program.read'),
     ('viewer',  'template.read'),

--- a/migrations/002_rbac_fix.sql
+++ b/migrations/002_rbac_fix.sql
@@ -64,6 +64,7 @@ VALUES
   ('task.create','Create tasks'),
   ('task.read','View tasks'),
   ('task.update','Edit/move tasks'),
+  ('task.assign','Assign tasks to dates/users'),
   ('task.delete','Delete tasks'),
   ('membership.manage','Add/remove users to programs'),
   ('admin.users.manage','Manage users / roles'),
@@ -105,7 +106,7 @@ BEGIN
     JOIN public.permissions p ON p.perm_key IN (
       'program.create','program.read','program.update',
       'template.create','template.read','template.update',
-      'task.create','task.read','task.update',
+      'task.create','task.read','task.update','task.assign',
       'membership.manage'
     )
     WHERE r.role_key = 'manager'

--- a/migrations/004_task_assign_permission.sql
+++ b/migrations/004_task_assign_permission.sql
@@ -1,0 +1,56 @@
+-- 004_task_assign_permission.sql
+-- Seed the task.assign permission and map it to admin/manager roles
+
+BEGIN;
+
+INSERT INTO public.permissions (perm_key, description)
+VALUES ('task.assign', 'Assign tasks to dates/users')
+ON CONFLICT (perm_key) DO UPDATE
+  SET description = EXCLUDED.description;
+
+DO $$
+DECLARE
+  has_perm_id  boolean;
+  has_perm_key boolean;
+  perm_assign_id integer;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'role_permissions'
+      AND column_name = 'perm_id'
+  ) INTO has_perm_id;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'role_permissions'
+      AND column_name = 'perm_key'
+  ) INTO has_perm_key;
+
+  IF has_perm_id THEN
+    SELECT perm_id INTO perm_assign_id
+    FROM public.permissions
+    WHERE perm_key = 'task.assign';
+
+    IF perm_assign_id IS NOT NULL THEN
+      INSERT INTO public.role_permissions (role_id, perm_id)
+      SELECT r.role_id, perm_assign_id
+      FROM public.roles r
+      WHERE r.role_key IN ('admin', 'manager')
+      ON CONFLICT DO NOTHING;
+    END IF;
+  ELSIF has_perm_key THEN
+    INSERT INTO public.role_permissions (role_id, perm_key)
+    SELECT r.role_id, 'task.assign'
+    FROM public.roles r
+    WHERE r.role_key IN ('admin', 'manager')
+    ON CONFLICT DO NOTHING;
+  ELSE
+    RAISE NOTICE 'role_permissions table is missing perm_id/perm_key; no task.assign mappings added.';
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add the task.assign permission to the baseline RBAC seed and role mappings
- ensure the normalization migration seeds task.assign and grants it to managers
- provide an idempotent patch migration that adds task.assign and assigns it to admin/manager roles

## Testing
- not run (SQL change only)


------
https://chatgpt.com/codex/tasks/task_e_68c83873512c832c865491d9b97bcff4