### PR TITLE
Stop including user_id in task PATCH payload

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -404,7 +404,7 @@ async function apiPatchTask(taskId, payload) {
   const res = await fetch(withUser(`${API}/tasks/${encodeURIComponent(taskId)}`), {
     method: 'PATCH', credentials:'include',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(withUserBody(payload))
+    body: JSON.stringify(payload)
   });
   if (res.status === 404) return null;
   if(res.status === 403){ alert('You do not have permission to perform this action.'); return null; }


### PR DESCRIPTION
## Summary
- avoid calling withUserBody when patching tasks so only intended fields reach the server

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c85af80240832c8e5994abdede4271