### PR TITLE
Ensure current user appears in orientation viewer

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -628,12 +628,26 @@ function App({ me, onSignOut }){
     (async () => {
       try {
         const list = await apiListUsers();
-        setUserList(list);
+        let normalized = Array.isArray(list) ? [...list] : [];
+        if (CURRENT_USER_ID) {
+          const hasCurrent = normalized.some(u => sameId(u.id, CURRENT_USER_ID));
+          if (!hasCurrent) {
+            const currentName = me?.name || me?.full_name || me?.username || 'Current user';
+            normalized = [
+              { id: CURRENT_USER_ID, full_name: currentName, name: currentName },
+              ...normalized,
+            ];
+          }
+        }
+        setUserList(normalized);
+        if (CURRENT_USER_ID) {
+          setTargetUserId(String(CURRENT_USER_ID));
+        }
       } catch (err) {
         console.error('Failed to load users', err);
       }
     })();
-  }, [isPrivileged]);
+  }, [isPrivileged, me]);
 
   useEffect(() => {
     if (!targetUserId) return;


### PR DESCRIPTION
## Summary
- ensure the privileged user list always includes the currently logged-in user
- reset the selected user after loading the list so the picker stays on the current user

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c86e59766c832cabfa11046c480b09