### PR TITLE
Add soft delete support to program task templates

### DIFF
--- a/migrations/006_soft_delete_program_task_templates.sql
+++ b/migrations/006_soft_delete_program_task_templates.sql
@@ -1,0 +1,5 @@
+-- 006_soft_delete_program_task_templates.sql
+-- Soft delete support for program task templates
+
+alter table public.program_task_templates
+  add column if not exists deleted_at timestamp null;


### PR DESCRIPTION
## Summary
- add a migration that introduces a deleted_at column on program_task_templates for soft deletes
- update template APIs to filter out soft-deleted rows, restore templates, and skip deleted templates during instantiation
- expand program route tests to cover soft delete, restore, and instantiate flows and to match the new schema

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c891eee4e4832c8ed70e97e9aae6e9