### PR TITLE
Use user IDs for trainee preference seed

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -191,7 +191,7 @@ app.get('/auth/google/callback',
       insert into public.user_preferences (user_id, trainee)
       values ($1, $2)
       on conflict (user_id) do nothing;`,
-      [req.user.id, req.user.full_name || '']);
+      [req.user.id, req.user.id]);
     if (req.session && req.user?.id) {
       req.session.trainee = req.user.id;
     }
@@ -226,7 +226,7 @@ app.post('/auth/local/register', async (req, res) => {
         insert into public.user_preferences (user_id, trainee)
         values ($1, $2)
         on conflict (user_id) do nothing;
-      `, [rows[0].id, rows[0].full_name || '']);
+      `, [rows[0].id, rows[0].id]);
     } catch (_e) {
       // ignore if preferences table absent
     }
@@ -262,7 +262,7 @@ app.post('/auth/local/login', async (req, res) => {
         insert into public.user_preferences (user_id, trainee)
         values ($1, $2)
         on conflict (user_id) do nothing;
-      `, [user.id, user.full_name || '']);
+      `, [user.id, user.id]);
     } catch (_e) {
       // ignore if preferences table is absent in tests
     }


### PR DESCRIPTION
## Summary
- update the Google, registration, and login flows to seed user_preferences.trainee with the authenticated user ID
- extend the in-memory test schema to match production defaults and add coverage that registration/login store the ID instead of the name

## Testing
- CI=1 npx jest

------
https://chatgpt.com/codex/tasks/task_e_68c89a699d4c832ca7af4144054c15ca