### PR TITLE
Add routes for users and programs

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
+import UsersLanding from './src/users/UsersLanding';
+import ProgramsLanding from './src/programs/ProgramsLanding';
+import { User } from './src/rbac';
+import { seed } from './src/api';
+
+const fallbackUser: User = {
+  id: 'fallback-admin',
+  name: 'Orientation Admin',
+  email: 'admin@example.com',
+  roles: ['admin'],
+  status: 'active',
+};
+
+const loggedInUser: User =
+  seed.users.find(user => user.roles.includes('admin')) ??
+  seed.users[0] ??
+  fallbackUser;
+
+export default function App(): JSX.Element {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/admin/users" element={<UsersLanding currentUser={loggedInUser} />} />
+        <Route path="/programs" element={<ProgramsLanding currentUser={loggedInUser} />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}


### PR DESCRIPTION
## Summary
- create a simple App.tsx router that loads the users and programs landing pages
- seed the router with a fallback admin user so both pages receive a valid currentUser prop

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8f297520c832cac631b974e420cb2