### PR TITLE
Add admin role manager quick navigation links

### DIFF
--- a/public/admin/role-manager.html
+++ b/public/admin/role-manager.html
@@ -11,9 +11,16 @@
 </head>
 <body class="bg-slate-50 text-slate-900">
   <div class="max-w-6xl mx-auto p-4 space-y-4">
-    <header class="flex items-center justify-between">
+    <header class="flex items-center justify-between gap-4">
       <h1 class="text-2xl font-bold">Role & Program Manager</h1>
-      <a href="/" class="text-sm text-anx-sky underline">← Back to Orientation</a>
+      <div class="flex items-center gap-3">
+        <div class="flex gap-2">
+          <a href="/admin/users" class="btn btn-outline text-sm">Manage Users</a>
+          <a href="/programs" class="btn btn-outline text-sm">Manage Programs</a>
+          <a href="/programs?tab=templates" class="btn btn-outline text-sm">Manage Templates</a>
+        </div>
+        <a href="/" class="text-sm text-anx-sky underline">← Back to Orientation</a>
+      </div>
     </header>
 
     <!-- User & role picker -->

--- a/src/programs/ProgramsLanding.tsx
+++ b/src/programs/ProgramsLanding.tsx
@@ -10,7 +10,13 @@ import {
 import { can, User } from '../rbac';
 
 export default function ProgramsLanding({ currentUser }: { currentUser: User }) {
-  const [tab, setTab] = useState<'programs' | 'templates' | 'assignments'>('programs');
+  const [tab, setTab] = useState<'programs' | 'templates' | 'assignments'>(() => {
+    if (typeof window === 'undefined') return 'programs';
+    const initialTab = new URLSearchParams(window.location.search).get('tab');
+    return initialTab === 'templates' || initialTab === 'assignments' || initialTab === 'programs'
+      ? initialTab
+      : 'programs';
+  });
   const [programs, setPrograms] = useState<any[]>([]);
   const [templates, setTemplates] = useState<any[]>([]);
 


### PR DESCRIPTION
## Summary
- add quick navigation buttons in the admin role manager header for users, programs, and templates
- initialize the programs landing tab from the URL query string so deep links open the correct view

## Testing
- npx jest --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c8f640f49c832ca75c7ef826ed9498