### PR TITLE
Route admin console through AdminLanding

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 
-import UsersLanding from './src/users/UsersLanding';
-import ProgramsLanding from './src/programs/ProgramsLanding';
+import AdminLanding from './src/AdminLanding';
 import { User } from './src/rbac';
 import { seed } from './src/api';
 
@@ -23,8 +22,9 @@ export default function App(): JSX.Element {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/admin/users" element={<UsersLanding currentUser={loggedInUser} />} />
-        <Route path="/programs" element={<ProgramsLanding currentUser={loggedInUser} />} />
+        <Route path="/admin" element={<AdminLanding currentUser={loggedInUser} />} />
+        <Route path="/admin/users" element={<Navigate to="/admin?tab=users" replace />} />
+        <Route path="/programs" element={<Navigate to="/admin?tab=programs" replace />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
## Summary
- import the AdminLanding console into the root app router
- expose /admin and redirect legacy admin URLs to the appropriate tabbed views

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9022cb034832c9493c125d5491510