### PR TITLE
Enforce RBAC controls on UsersLanding actions

### DIFF
--- a/__tests__/usersLandingPermissions.test.ts
+++ b/__tests__/usersLandingPermissions.test.ts
@@ -1,0 +1,79 @@
+import { getActionAvailability, ALL_ROLES, MANAGER_EDITABLE_ROLES } from '../src/users/actionPermissions';
+import { Role, User } from '../src/rbac';
+
+const buildUser = (roles: Role[], status: User['status'] = 'active'): User => ({
+  id: 'user-id',
+  name: 'Test User',
+  email: 'test@example.com',
+  roles,
+  status,
+});
+
+const buildActor = (roles: Role[]): User => ({
+  id: 'actor-id',
+  name: 'Actor',
+  email: 'actor@example.com',
+  roles,
+  status: 'active',
+});
+
+describe('getActionAvailability', () => {
+  it('grants admins full lifecycle controls', () => {
+    const admin = buildActor(['admin']);
+    const targetActive = buildUser(['viewer'], 'active');
+    const targetSuspended = buildUser(['viewer'], 'suspended');
+
+    const activeAvailability = getActionAvailability(admin, targetActive);
+    const suspendedAvailability = getActionAvailability(admin, targetSuspended);
+
+    expect(activeAvailability.canInvite).toBe(true);
+    expect(activeAvailability.canEdit).toBe(true);
+    expect(activeAvailability.canManageRoles).toBe(true);
+    expect(activeAvailability.canAssignPrograms).toBe(true);
+    expect(activeAvailability.canDeactivate).toBe(true);
+    expect(activeAvailability.canReactivate).toBe(false);
+    expect(activeAvailability.toggleableRoles).toEqual(ALL_ROLES);
+    expect(activeAvailability.lockedRoles).toEqual([]);
+    expect(activeAvailability.managerOnly).toBe(false);
+
+    expect(suspendedAvailability.canReactivate).toBe(true);
+  });
+
+  it('limits managers to viewer/trainee role toggles', () => {
+    const manager = buildActor(['manager']);
+    const target = buildUser(['manager', 'viewer'], 'active');
+
+    const availability = getActionAvailability(manager, target);
+
+    expect(availability.canInvite).toBe(false);
+    expect(availability.canEdit).toBe(false);
+    expect(availability.canManageRoles).toBe(true);
+    expect(availability.canAssignPrograms).toBe(true);
+    expect(availability.canDeactivate).toBe(false);
+    expect(availability.canReactivate).toBe(false);
+    expect(availability.toggleableRoles).toEqual(MANAGER_EDITABLE_ROLES);
+    expect(availability.lockedRoles).toContain('manager');
+    expect(availability.managerOnly).toBe(true);
+  });
+
+  it('treats viewers as read-only users', () => {
+    const viewer = buildActor(['viewer']);
+    const targetActive = buildUser(['viewer'], 'active');
+    const targetSuspended = buildUser(['viewer'], 'suspended');
+
+    const activeAvailability = getActionAvailability(viewer, targetActive);
+    const suspendedAvailability = getActionAvailability(viewer, targetSuspended);
+
+    expect(activeAvailability.canInvite).toBe(false);
+    expect(activeAvailability.canEdit).toBe(false);
+    expect(activeAvailability.canManageRoles).toBe(false);
+    expect(activeAvailability.canAssignPrograms).toBe(false);
+    expect(activeAvailability.canDeactivate).toBe(false);
+    expect(activeAvailability.canReactivate).toBe(false);
+    expect(activeAvailability.toggleableRoles).toEqual([]);
+    expect(activeAvailability.lockedRoles).toEqual([]);
+    expect(activeAvailability.managerOnly).toBe(false);
+
+    expect(suspendedAvailability.canReactivate).toBe(false);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.(ts|tsx)$': '<rootDir>/test-utils/esbuild-jest-transform.js',
+  },
+  testMatch: [
+    '**/__tests__/**/*.{spec,test}.[tj]s?(x)',
+    '**/?(*.)+(spec|test).[tj]s?(x)',
+  ],
+};

--- a/src/rbac.ts
+++ b/src/rbac.ts
@@ -17,7 +17,7 @@ const policy: Record<string, Record<string, Role[]>> = {
     create: ['admin'],
     read: ['admin', 'manager', 'viewer', 'trainee'],
     update: ['admin'],
-    manageRoles: ['admin'],
+    manageRoles: ['admin', 'manager'],
     assignPrograms: ['admin', 'manager'],
     deactivate: ['admin'],
     reactivate: ['admin'],

--- a/src/users/actionPermissions.ts
+++ b/src/users/actionPermissions.ts
@@ -1,0 +1,52 @@
+import { can, hasRole, Role, User } from '../rbac';
+
+export const ALL_ROLES: Role[] = ['admin', 'manager', 'viewer', 'trainee'];
+export const MANAGER_EDITABLE_ROLES: Role[] = ['viewer', 'trainee'];
+
+export interface UserActionAvailability {
+  canInvite: boolean;
+  canEdit: boolean;
+  canManageRoles: boolean;
+  canAssignPrograms: boolean;
+  canDeactivate: boolean;
+  canReactivate: boolean;
+  toggleableRoles: Role[];
+  lockedRoles: Role[];
+  managerOnly: boolean;
+}
+
+export const getActionAvailability = (
+  currentUser: User,
+  targetUser?: User | null,
+): UserActionAvailability => {
+  const canManage = can(currentUser, 'manageRoles', 'user');
+  const isAdmin = hasRole(currentUser, 'admin');
+  const isManager = hasRole(currentUser, 'manager');
+  const managerOnly = !isAdmin && isManager;
+
+  const toggleableRoles = canManage
+    ? managerOnly
+      ? MANAGER_EDITABLE_ROLES
+      : ALL_ROLES
+    : [];
+
+  const lockedRoles = managerOnly && targetUser
+    ? targetUser.roles.filter(role => !MANAGER_EDITABLE_ROLES.includes(role))
+    : [];
+
+  return {
+    canInvite: can(currentUser, 'create', 'user'),
+    canEdit: can(currentUser, 'update', 'user'),
+    canManageRoles: canManage,
+    canAssignPrograms: can(currentUser, 'assignPrograms', 'user'),
+    canDeactivate: Boolean(
+      targetUser && targetUser.status !== 'suspended' && can(currentUser, 'deactivate', 'user'),
+    ),
+    canReactivate: Boolean(
+      targetUser && targetUser.status === 'suspended' && can(currentUser, 'reactivate', 'user'),
+    ),
+    toggleableRoles,
+    lockedRoles,
+    managerOnly,
+  };
+};

--- a/test-utils/esbuild-jest-transform.js
+++ b/test-utils/esbuild-jest-transform.js
@@ -1,0 +1,18 @@
+const { transformSync } = require('esbuild');
+
+module.exports = {
+  process(src, filename) {
+    const loader = filename.endsWith('.tsx')
+      ? 'tsx'
+      : filename.endsWith('.ts')
+      ? 'ts'
+      : 'js';
+    const result = transformSync(src, {
+      loader,
+      format: 'cjs',
+      target: 'es2019',
+      sourcemap: 'inline',
+    });
+    return { code: result.code, map: result.map || '' };
+  },
+};


### PR DESCRIPTION
## Summary
- gate UsersLanding handlers and UI affordances with RBAC checks and add a manager-limited roles drawer
- share a helper for computing user action availability and allow managers to toggle only viewer/trainee roles
- configure Jest to compile TypeScript with esbuild and add unit tests covering admin, manager, and viewer permissions

## Testing
- npm test
- npx jest --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68c9274520a4832ca60e0890b1b0e21f