### PR TITLE
Add modals for user lifecycle operations

### DIFF
--- a/src/users/AssignProgramsModal.tsx
+++ b/src/users/AssignProgramsModal.tsx
@@ -1,0 +1,151 @@
+import React, { FormEvent, useEffect, useMemo, useState } from 'react';
+import type { Program } from '../api';
+import { User } from '../rbac';
+import UserModal from './UserModal';
+
+export interface AssignProgramsModalProps {
+  open: boolean;
+  user: User | null;
+  programs: Program[];
+  onClose: () => void;
+  onAssign: (
+    values: { programId: string; startDate: string; dueDate: string; notes?: string },
+  ) => Promise<void>;
+}
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+export default function AssignProgramsModal({
+  open,
+  user,
+  programs,
+  onClose,
+  onAssign,
+}: AssignProgramsModalProps) {
+  const [programId, setProgramId] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const hasPrograms = useMemo(() => programs && programs.length > 0, [programs]);
+
+  useEffect(() => {
+    if (open) {
+      setProgramId(programs[0]?.id ?? '');
+      const defaultStart = today();
+      setStartDate(defaultStart);
+      setDueDate(defaultStart);
+      setNotes('');
+      setError('');
+      setSubmitting(false);
+    }
+  }, [open, programs]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!user || !programId || !startDate || !dueDate) return;
+    try {
+      setSubmitting(true);
+      setError('');
+      await onAssign({
+        programId,
+        startDate,
+        dueDate,
+        notes: notes.trim() ? notes.trim() : undefined,
+      });
+      onClose();
+    } catch (_err) {
+      setError('Unable to assign the program. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <UserModal
+      open={open}
+      onClose={onClose}
+      title={user ? `Assign program to ${user.name}` : 'Assign program'}
+      footer={
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="px-3 py-2 text-sm rounded-md text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            form="assign-program-form"
+            className="px-4 py-2 text-sm font-medium rounded-md bg-[var(--brand-primary)] text-white disabled:opacity-60"
+            disabled={!hasPrograms || !programId || !startDate || !dueDate || submitting}
+          >
+            {submitting ? 'Assigning…' : 'Assign program'}
+          </button>
+        </div>
+      }
+    >
+      <form id="assign-program-form" className="space-y-4" onSubmit={handleSubmit}>
+        <div className="space-y-1">
+          <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+            Program
+          </label>
+          <select
+            className="w-full border border-[var(--border)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
+            value={programId}
+            onChange={event => setProgramId(event.target.value)}
+            disabled={!hasPrograms}
+          >
+            {!hasPrograms && <option value="">No programs available</option>}
+            {programs.map(program => (
+              <option key={program.id} value={program.id}>
+                {program.name} · v{program.version}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="space-y-1">
+            <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Start date
+            </label>
+            <input
+              className="w-full border border-[var(--border)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
+              type="date"
+              value={startDate}
+              onChange={event => setStartDate(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Due date
+            </label>
+            <input
+              className="w-full border border-[var(--border)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
+              type="date"
+              value={dueDate}
+              min={startDate}
+              onChange={event => setDueDate(event.target.value)}
+            />
+          </div>
+        </div>
+        <div className="space-y-1">
+          <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+            Notes (optional)
+          </label>
+          <textarea
+            className="w-full h-24 border border-[var(--border)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
+            value={notes}
+            onChange={event => setNotes(event.target.value)}
+            placeholder="Add context for the assignee"
+          />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </form>
+    </UserModal>
+  );
+}

--- a/src/users/ConfirmUserActionModal.tsx
+++ b/src/users/ConfirmUserActionModal.tsx
@@ -1,0 +1,130 @@
+import React, { FormEvent, useEffect, useMemo, useState } from 'react';
+import { User } from '../rbac';
+import UserModal from './UserModal';
+
+type UserLifecycleAction = 'deactivate' | 'reactivate' | 'archive';
+
+export interface ConfirmUserActionModalProps {
+  open: boolean;
+  user: User | null;
+  action: UserLifecycleAction;
+  onClose: () => void;
+  onConfirm: (reason?: string) => Promise<void>;
+}
+
+const ACTION_COPY: Record<UserLifecycleAction, { title: string; description: string; confirmLabel: string }> = {
+  deactivate: {
+    title: 'Deactivate user',
+    description:
+      'The user will immediately lose access to the platform. You can reactivate their access at any time.',
+    confirmLabel: 'Deactivate user',
+  },
+  reactivate: {
+    title: 'Reactivate user',
+    description:
+      'The user will regain access to the platform and receive an email letting them know their account is active.',
+    confirmLabel: 'Reactivate user',
+  },
+  archive: {
+    title: 'Archive user',
+    description:
+      'Archiving removes the user from active rosters but retains their history for compliance reporting.',
+    confirmLabel: 'Archive user',
+  },
+};
+
+export default function ConfirmUserActionModal({
+  open,
+  user,
+  action,
+  onClose,
+  onConfirm,
+}: ConfirmUserActionModalProps) {
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const copy = ACTION_COPY[action];
+
+  const confirmButtonClass = useMemo(() => {
+    const base = 'px-4 py-2 text-sm font-medium rounded-md text-white disabled:opacity-60';
+    if (action === 'reactivate') {
+      return `${base} bg-[var(--brand-primary)]`;
+    }
+    return `${base} bg-red-600`;
+  }, [action]);
+
+  useEffect(() => {
+    if (open) {
+      setReason('');
+      setError('');
+      setSubmitting(false);
+    }
+  }, [open, action, user]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!user) return;
+    try {
+      setSubmitting(true);
+      setError('');
+      await onConfirm(action === 'deactivate' ? reason.trim() : undefined);
+      onClose();
+    } catch (_err) {
+      setError('Unable to complete the request. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <UserModal
+      open={open}
+      onClose={onClose}
+      title={user ? `${copy.title} – ${user.name}` : copy.title}
+      footer={
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="px-3 py-2 text-sm rounded-md text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            form="confirm-user-action"
+            className={confirmButtonClass}
+            disabled={submitting || (action === 'deactivate' && !reason.trim())}
+          >
+            {submitting ? 'Working…' : copy.confirmLabel}
+          </button>
+        </div>
+      }
+    >
+      <form id="confirm-user-action" className="space-y-4" onSubmit={handleSubmit}>
+        <div className="rounded-lg border border-[var(--border)] bg-[var(--surface-alt)] px-4 py-3 text-sm">
+          <p>
+            <span className="font-medium">{user?.name}</span> will be {action === 'reactivate' ? 'restored' : action}.
+          </p>
+          <p className="mt-2 text-[var(--text-muted)]">{copy.description}</p>
+        </div>
+        {action === 'deactivate' && (
+          <div className="space-y-1">
+            <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+              Reason for deactivation
+            </label>
+            <textarea
+              className="w-full h-24 border border-[var(--border)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
+              value={reason}
+              onChange={event => setReason(event.target.value)}
+              placeholder="Share why the account is being deactivated"
+            />
+          </div>
+        )}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </form>
+    </UserModal>
+  );
+}

--- a/src/users/EditUserModal.tsx
+++ b/src/users/EditUserModal.tsx
@@ -1,0 +1,100 @@
+import React, { FormEvent, useEffect, useState } from 'react';
+import { User } from '../rbac';
+import UserModal from './UserModal';
+
+export interface EditUserModalProps {
+  open: boolean;
+  user: Pick<User, 'name' | 'email'> | null;
+  onClose: () => void;
+  onSave: (values: { name: string; email: string }) => Promise<void>;
+}
+
+export default function EditUserModal({ open, user, onClose, onSave }: EditUserModalProps) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (open && user) {
+      setName(user.name);
+      setEmail(user.email);
+    }
+    if (!open) {
+      setName('');
+      setEmail('');
+      setError('');
+      setSubmitting(false);
+    }
+  }, [open, user]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!user) return;
+    try {
+      setSubmitting(true);
+      setError('');
+      await onSave({ name: name.trim(), email: email.trim() });
+      onClose();
+    } catch (_err) {
+      setError('Unable to update the profile. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <UserModal
+      open={open}
+      onClose={onClose}
+      title={user ? `Edit ${user.name}` : 'Edit user'}
+      footer={
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            className="px-3 py-2 text-sm rounded-md text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            form="edit-user-form"
+            className="px-4 py-2 text-sm font-medium rounded-md bg-[var(--brand-primary)] text-white disabled:opacity-60"
+            disabled={!name.trim() || !email.trim() || submitting}
+          >
+            {submitting ? 'Saving…' : 'Save changes'}
+          </button>
+        </div>
+      }
+    >
+      <form id="edit-user-form" className="space-y-4" onSubmit={handleSubmit}>
+        <div className="space-y-1">
+          <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+            Full name
+          </label>
+          <input
+            className="w-full border border-[var(--border)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
+            value={name}
+            onChange={event => setName(event.target.value)}
+            placeholder="Jane Doe"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+            Email address
+          </label>
+          <input
+            className="w-full border border-[var(--border)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
+            type="email"
+            value={email}
+            onChange={event => setEmail(event.target.value)}
+            placeholder="name@example.com"
+          />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+      </form>
+    </UserModal>
+  );
+}

--- a/src/users/UserModal.tsx
+++ b/src/users/UserModal.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export interface UserModalProps {
+  open: boolean;
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  widthClassName?: string;
+}
+
+export default function UserModal({
+  open,
+  title,
+  onClose,
+  children,
+  footer,
+  widthClassName = 'max-w-lg',
+}: UserModalProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className={`w-full ${widthClassName} bg-[var(--surface)] rounded-2xl shadow-xl border border-[var(--border)]`}
+        onClick={event => event.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-6 py-4 border-b border-[var(--border)]">
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close dialog"
+            className="text-xl leading-none text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+          >
+            &times;
+          </button>
+        </header>
+        <div className="px-6 py-5 space-y-4 text-sm">{children}</div>
+        {footer && (
+          <footer className="px-6 py-4 border-t border-[var(--border)] bg-[var(--surface-alt)]">
+            {footer}
+          </footer>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/users/actionPermissions.ts
+++ b/src/users/actionPermissions.ts
@@ -10,6 +10,7 @@ export interface UserActionAvailability {
   canAssignPrograms: boolean;
   canDeactivate: boolean;
   canReactivate: boolean;
+  canArchive: boolean;
   toggleableRoles: Role[];
   lockedRoles: Role[];
   managerOnly: boolean;
@@ -44,6 +45,9 @@ export const getActionAvailability = (
     ),
     canReactivate: Boolean(
       targetUser && targetUser.status === 'suspended' && can(currentUser, 'reactivate', 'user'),
+    ),
+    canArchive: Boolean(
+      targetUser && targetUser.status !== 'archived' && can(currentUser, 'archive', 'user'),
     ),
     toggleableRoles,
     lockedRoles,


### PR DESCRIPTION
## Summary
- add themed modal shell plus dedicated edit profile, assign program, and confirm action dialogs for users
- wire the new dialogs into the users landing page to call update, assign, deactivate, reactivate, and archive APIs and refresh the list
- load program options when assignment is available and expose archive permissions to row actions

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c92d22fdbc832caab7d3bcb89a2336