### PR TITLE
Wire admin navigation to new user manager

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -391,6 +391,14 @@ function ensurePerm(...permKeys) {
   };
 }
 
+app.get('/admin/user-manager', ensureAuth, (req, res) => {
+  const roles = req.roles || [];
+  if (!(roles.includes('admin') || roles.includes('manager'))) {
+    return res.status(403).send('forbidden');
+  }
+  res.sendFile(path.join(PUBLIC_DIR, 'admin', 'user-manager.html'));
+});
+
 async function userManagesProgram(userId, programId) {
   if (!userId || !programId) return false;
   const { rowCount } = await pool.query(

--- a/public/admin/role-manager.html
+++ b/public/admin/role-manager.html
@@ -12,12 +12,16 @@
 <body class="bg-slate-50 text-slate-900">
   <div class="max-w-6xl mx-auto p-4 space-y-4">
     <header class="flex items-center justify-between gap-4">
-      <h1 class="text-2xl font-bold">Role & Program Manager</h1>
+      <div>
+        <h1 class="text-2xl font-bold">Role &amp; Program Manager</h1>
+        <p class="text-sm text-slate-500">Manage permissions and preload programs for your team.</p>
+      </div>
       <div class="flex items-center gap-3">
         <div class="flex gap-2">
-          <a href="/admin/users" class="btn btn-outline text-sm">Manage Users</a>
-          <a href="/programs" class="btn btn-outline text-sm">Manage Programs</a>
-          <a href="/programs?tab=templates" class="btn btn-outline text-sm">Manage Templates</a>
+          <a href="/admin/user-manager" class="btn btn-outline text-sm">Users</a>
+          <a href="/admin/role-manager.html" class="btn btn-outline text-sm bg-anx-sky text-white">Roles &amp; Programs</a>
+          <a href="/programs" class="btn btn-outline text-sm">Programs</a>
+          <a href="/programs?tab=templates" class="btn btn-outline text-sm">Templates</a>
         </div>
         <a href="/" class="text-sm text-anx-sky underline">← Back to Orientation</a>
       </div>

--- a/public/admin/user-manager.html
+++ b/public/admin/user-manager.html
@@ -18,7 +18,7 @@
       </div>
       <div class="flex items-center gap-3">
         <div class="flex gap-2">
-          <a href="/admin/user-manager.html" class="btn btn-outline text-sm bg-anx-sky text-white">Users</a>
+          <a href="/admin/user-manager" class="btn btn-outline text-sm bg-anx-sky text-white">Users</a>
           <a href="/admin/role-manager.html" class="btn btn-outline text-sm">Roles &amp; Programs</a>
           <a href="/programs" class="btn btn-outline text-sm">Programs</a>
           <a href="/programs?tab=templates" class="btn btn-outline text-sm">Templates</a>

--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -1768,10 +1768,15 @@ useEffect(() => {
                 <button className="btn btn-outline w-full" onClick={() => refreshPrograms()}>
                   Refresh Programs
                 </button>
+                {(me.roles?.includes('admin') || me.roles?.includes('manager')) && (
+                  <button className="btn btn-outline w-full" onClick={() => (window.location.href = '/admin/user-manager')}>
+                    User Manager
+                  </button>
+                )}
                 {me.roles?.includes('admin') && (
                 <button className="btn-outline w-full" onClick={() => window.location.href = '/admin/role-manager.html'}>
-					      Role Manager
-				        </button>
+                                              Role Manager
+                                        </button>
                 )}
                 <button className="btn btn-outline w-full" disabled>
                   Clear Cache (coming soon)

--- a/src/programs/ProgramsLanding.tsx
+++ b/src/programs/ProgramsLanding.tsx
@@ -25,10 +25,43 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
     if (tab === 'templates') getTemplates({}).then(r => setTemplates(r.data));
   }, [tab]);
 
+  const navLinkBase =
+    'inline-flex items-center justify-center px-3 py-1.5 rounded-full border text-sm transition-colors';
+  const navLinkActive = 'bg-[var(--brand-primary)] text-white border-[var(--brand-primary)]';
+  const navLinkInactive =
+    'bg-[var(--surface)] text-[var(--text-primary)] border-[var(--border)] hover:bg-[var(--surface-alt)]';
+  const navLinkClass = (isActive: boolean) =>
+    `${navLinkBase} ${isActive ? navLinkActive : navLinkInactive}`;
+  const isTemplatesView = tab === 'templates';
+
   return (
     <div className="p-8 space-y-6">
-      <header className="space-y-2">
-        <h1 className="text-2xl font-bold">Programs & Templates</h1>
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold">Programs & Templates</h1>
+          <p className="text-sm text-[var(--text-muted)]">
+            Publish, template, and assign onboarding experiences for your teammates.
+          </p>
+        </div>
+        <div className="flex flex-col items-start gap-3 md:items-end">
+          <nav className="flex flex-wrap gap-2">
+            <a href="/admin/user-manager" className={navLinkClass(false)}>
+              Users
+            </a>
+            <a href="/admin/role-manager.html" className={navLinkClass(false)}>
+              Roles &amp; Programs
+            </a>
+            <a href="/programs" className={navLinkClass(!isTemplatesView)}>
+              Programs
+            </a>
+            <a href="/programs?tab=templates" className={navLinkClass(isTemplatesView)}>
+              Templates
+            </a>
+          </nav>
+          <a href="/" className="text-sm text-[var(--brand-primary)] underline">
+            ← Back to Orientation
+          </a>
+        </div>
       </header>
 
       {/* Segmented Tabs */}


### PR DESCRIPTION
## Summary
- expose `/admin/user-manager` through the Express server with an auth/role gate so the new admin page can be loaded securely
- refresh the admin navigation on the role manager and user manager pages and in the programs UI so they cross-link Users, Roles, Programs, and Templates
- surface a quick access button for the user manager in the Orientation utilities drawer

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c932c6adb8832c87d05dc4a59e33e7