### PR TITLE
Revamp role manager UI and tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,34 @@ The application includes an account and settings side panel on the right. On sma
 panel slides in when the chevron toggle at the screen edge is tapped and closes when the backdrop is clicked or the
 Escape key is pressed. On larger screens it remains visible.
 
-The panel container uses the shared `card` class, while its buttons and form fields use the
-common `btn` and `input` classes to keep styling consistent across the app.
+The panel now shares styling tokens with the admin role manager. Wrap the outer container in a
+`panel` class and any nested sections in `panel-section` to inherit the rounded corners, borders, and
+surface colors. Buttons inside the panel should use the base `btn` class with one of the variants
+(`btn-primary`, `btn-outline`, or `btn-ghost`). Form inputs share the `form-field` utility (alias `input`).
+This keeps typography, spacing, and focus states consistent across admin pages.
+
+## Design tokens & utilities
+
+Color variables are defined in `src/styles.css` (`--brand-primary`, `--surface`, `--text-muted`, etc.)
+and mirrored in `tailwind.config.ts` as the `brand`, `surface`, `ink`, `border`, and `focus` color
+groups. Use the Tailwind classes generated from these tokens (`bg-surface`, `bg-surface-alt`,
+`text-ink`, `text-ink-muted`, `border-border`, `ring-focus`) to keep layouts on brand without
+falling back to arbitrary values.
+
+Shared component classes introduced for the role manager:
+
+- `panel` and `panel-section` – Card containers with rounded corners, border, and subtle shadowing
+  for primary and nested sections respectively.
+- `label-text` – Uppercase caption styling for field labels.
+- `form-field` / `input` – Rounded text input with shared focus ring using the `focus` token.
+- `btn` – Base button styling with consistent spacing, rounded corners, disabled states, and
+  accessible focus ring. Pair with:
+  - `btn-primary` for filled actions using the brand color.
+  - `btn-outline` for neutral bordered actions on surface backgrounds.
+  - `btn-ghost` for low-emphasis text buttons.
+
+When creating new interactions, prefer these utilities over bespoke styles so future contributors
+inherit the same spacing, typography, and color behavior.
 
 
 ## Migrations

--- a/src/admin/RoleManager.jsx
+++ b/src/admin/RoleManager.jsx
@@ -1,101 +1,549 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import ReactDOM from 'react-dom/client';
 
-// Roles available in the system
-const ALL_ROLES = ['admin', 'manager', 'viewer', 'trainee'];
+const ALL_ROLES = ['admin', 'manager', 'viewer', 'trainee', 'auditor'];
+const MANAGER_EDITABLE_ROLES = ['viewer', 'trainee'];
 
-export default function RoleManager(){
-  const [me, setMe] = useState(null);
+const createStatus = () => ({ message: '', error: '' });
+
+function normalizeRoles(list = []) {
+  return Array.from(new Set(list)).sort();
+}
+
+export default function RoleManager() {
+  const [currentUser, setCurrentUser] = useState(null);
+  const [loadingMe, setLoadingMe] = useState(true);
+  const [generalError, setGeneralError] = useState('');
+
   const [users, setUsers] = useState([]);
-  const [msg, setMsg] = useState('');
-  const [err, setErr] = useState('');
+  const [usersLoading, setUsersLoading] = useState(false);
+  const [usersError, setUsersError] = useState('');
+
+  const [programs, setPrograms] = useState([]);
+  const [programsLoading, setProgramsLoading] = useState(false);
+  const [programsError, setProgramsError] = useState('');
+
+  const [query, setQuery] = useState('');
+  const [selectedUserId, setSelectedUserId] = useState('');
+  const [roleDraft, setRoleDraft] = useState([]);
+  const [rolesStatus, setRolesStatus] = useState(createStatus);
+  const [savingRoles, setSavingRoles] = useState(false);
+
+  const [selectedProgramIds, setSelectedProgramIds] = useState([]);
+  const [preloadStatus, setPreloadStatus] = useState(createStatus);
+  const [preloadingPrograms, setPreloadingPrograms] = useState(false);
 
   useEffect(() => {
+    let active = true;
+    setLoadingMe(true);
+    setGeneralError('');
     (async () => {
-      const meRes = await fetch('/me');
-      const meData = await meRes.json();
-      setMe(meData);
-      if(!meData.roles?.some(r => ['admin', 'manager'].includes(r))) return;
-      const res = await fetch('/rbac/users');
-      if(res.ok){
-        const data = await res.json();
-        setUsers(data);
+      try {
+        const response = await fetch('/me', { credentials: 'include' });
+        if (!response.ok) throw new Error('me');
+        const meData = await response.json();
+        if (!active) return;
+        setCurrentUser(meData);
+      } catch (error) {
+        if (!active) return;
+        setCurrentUser(null);
+        setGeneralError('We could not verify your session. Please refresh the page.');
+      } finally {
+        if (active) setLoadingMe(false);
       }
     })();
+    return () => {
+      active = false;
+    };
   }, []);
 
-  if(!me) return <div>Loading…</div>;
-  if(!me.roles?.some(r => ['admin', 'manager'].includes(r))) return <div className="card p-6">Access denied</div>;
+  const canManage = useMemo(() => {
+    const roles = currentUser?.roles || [];
+    return roles.some(role => role === 'admin' || role === 'manager');
+  }, [currentUser]);
 
-  const isAdmin = me.roles.includes('admin');
-  const isManager = me.roles.includes('manager');
+  const isAdmin = useMemo(() => Boolean(currentUser?.roles?.includes('admin')), [currentUser]);
+  const isManager = useMemo(() => Boolean(currentUser?.roles?.includes('manager')), [currentUser]);
   const managerOnly = isManager && !isAdmin;
-  const MANAGER_EDITABLE_ROLES = ['viewer', 'trainee'];
 
-  const toggleRole = (userId, role) => {
-    if (managerOnly && !MANAGER_EDITABLE_ROLES.includes(role)) return;
-    setUsers(prev => prev.map(u => u.id === userId ? {
-      ...u,
-      roles: u.roles.includes(role) ? u.roles.filter(r => r !== role) : [...u.roles, role]
-    } : u));
+  const fetchUsers = useCallback(async () => {
+    setUsersLoading(true);
+    try {
+      const response = await fetch('/rbac/users', { credentials: 'include' });
+      if (!response.ok) throw new Error('users');
+      const data = await response.json();
+      if (!Array.isArray(data)) throw new Error('users');
+      setUsers(
+        data.map(user => ({
+          ...user,
+          roles: Array.isArray(user.roles) ? user.roles : [],
+        })),
+      );
+      setUsersError('');
+      return true;
+    } catch (_error) {
+      setUsers([]);
+      setUsersError('Unable to load users. Please try again.');
+      return false;
+    } finally {
+      setUsersLoading(false);
+    }
+  }, []);
+
+  const fetchPrograms = useCallback(async () => {
+    setProgramsLoading(true);
+    try {
+      const response = await fetch('/programs', { credentials: 'include' });
+      if (!response.ok) throw new Error('programs');
+      const data = await response.json();
+      if (!Array.isArray(data)) throw new Error('programs');
+      setPrograms(data);
+      setProgramsError('');
+      return true;
+    } catch (_error) {
+      setPrograms([]);
+      setProgramsError('Unable to load programs. Preloading will be unavailable.');
+      return false;
+    } finally {
+      setProgramsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!currentUser || !canManage) return;
+    let active = true;
+    (async () => {
+      const [usersOk, programsOk] = await Promise.all([fetchUsers(), fetchPrograms()]);
+      if (!active) return;
+      if (usersOk && programsOk) {
+        setGeneralError('');
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [currentUser, canManage, fetchUsers, fetchPrograms]);
+
+  const filteredUsers = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return users;
+    return users.filter(user => {
+      const name = (user.full_name || user.name || '').toLowerCase();
+      const username = (user.username || user.email || '').toLowerCase();
+      return name.includes(term) || username.includes(term);
+    });
+  }, [users, query]);
+
+  useEffect(() => {
+    if (!users.length) {
+      setSelectedUserId('');
+      return;
+    }
+    const stillSelected = users.some(user => user.id === selectedUserId);
+    if (!stillSelected) {
+      setSelectedUserId(users[0].id);
+    }
+  }, [users, selectedUserId]);
+
+  const selectedUser = useMemo(
+    () => users.find(user => user.id === selectedUserId) || null,
+    [users, selectedUserId],
+  );
+
+  useEffect(() => {
+    if (selectedUser) {
+      setRoleDraft(Array.isArray(selectedUser.roles) ? selectedUser.roles : []);
+    } else {
+      setRoleDraft([]);
+    }
+    setRolesStatus(createStatus());
+    setSelectedProgramIds([]);
+    setPreloadStatus(createStatus());
+  }, [selectedUser]);
+
+  const sanitizedDraft = useMemo(() => {
+    const base = Array.isArray(roleDraft) ? roleDraft : [];
+    const unique = Array.from(new Set(base));
+    return managerOnly ? unique.filter(role => MANAGER_EDITABLE_ROLES.includes(role)) : unique;
+  }, [roleDraft, managerOnly]);
+
+  const comparableCurrentRoles = useMemo(() => {
+    if (!selectedUser) return [];
+    const base = Array.isArray(selectedUser.roles) ? selectedUser.roles : [];
+    const filtered = managerOnly ? base.filter(role => MANAGER_EDITABLE_ROLES.includes(role)) : base;
+    return Array.from(new Set(filtered));
+  }, [selectedUser, managerOnly]);
+
+  const hasRoleChanges = useMemo(() => {
+    if (!selectedUser) return false;
+    return (
+      normalizeRoles(sanitizedDraft).join('|') !==
+      normalizeRoles(comparableCurrentRoles).join('|')
+    );
+  }, [selectedUser, sanitizedDraft, comparableCurrentRoles]);
+
+  const sortedPrograms = useMemo(() => {
+    return [...programs].sort((a, b) => {
+      const labelA = (a.title || a.name || '').toLowerCase();
+      const labelB = (b.title || b.name || '').toLowerCase();
+      return labelA.localeCompare(labelB);
+    });
+  }, [programs]);
+
+  const handleRefreshUsers = async () => {
+    await fetchUsers();
   };
 
-  const handleSave = async () => {
-    setMsg('');
-    setErr('');
+  const handleToggleRole = role => {
+    if (!selectedUser) return;
+    if (managerOnly && !MANAGER_EDITABLE_ROLES.includes(role)) return;
+    setRoleDraft(prev => (prev.includes(role) ? prev.filter(r => r !== role) : [...prev, role]));
+  };
+
+  const handleSaveRoles = async () => {
+    if (!selectedUser || !hasRoleChanges) return;
+    setSavingRoles(true);
+    setRolesStatus(createStatus());
     try {
-      for(const u of users){
-        const roles = managerOnly ? u.roles.filter(r => MANAGER_EDITABLE_ROLES.includes(r)) : u.roles;
-        const resp = await fetch(`/rbac/users/${u.id}/roles`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ roles })
-        });
-        if(!resp.ok) throw new Error('Save failed');
-      }
-      setMsg('Saved');
-    } catch (_e){
-      setErr('Save failed');
+      const nextRoles = managerOnly
+        ? sanitizedDraft.filter(role => MANAGER_EDITABLE_ROLES.includes(role))
+        : sanitizedDraft;
+      const response = await fetch(`/rbac/users/${selectedUser.id}/roles`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ roles: nextRoles }),
+      });
+      if (!response.ok) throw new Error('save');
+      setUsers(prev =>
+        prev.map(user => (user.id === selectedUser.id ? { ...user, roles: nextRoles } : user)),
+      );
+      setRolesStatus({
+        message: 'Roles updated successfully.',
+        error: '',
+      });
+    } catch (_error) {
+      setRolesStatus({
+        message: '',
+        error: 'Unable to update roles. Please try again.',
+      });
+    } finally {
+      setSavingRoles(false);
     }
   };
 
-  return (
-    <div className="max-w-4xl mx-auto p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Role Manager</h1>
-      <div className="text-sm text-slate-600">
-        Admin: full access. Manager: manage orientation programs and tasks. Viewer: read-only access. Trainee: view their own tasks.
+  const handleToggleProgram = programId => {
+    setSelectedProgramIds(prev =>
+      prev.includes(programId) ? prev.filter(id => id !== programId) : [...prev, programId],
+    );
+  };
+
+  const handlePreloadPrograms = async () => {
+    if (!selectedUser) return;
+    if (!selectedProgramIds.length) {
+      setPreloadStatus({
+        message: '',
+        error: 'Select at least one program to preload.',
+      });
+      return;
+    }
+    setPreloadingPrograms(true);
+    setPreloadStatus(createStatus());
+    try {
+      for (const programId of selectedProgramIds) {
+        const response = await fetch(
+          `/rbac/users/${selectedUser.id}/programs/${encodeURIComponent(programId)}/instantiate`,
+          {
+            method: 'POST',
+            credentials: 'include',
+          },
+        );
+        if (!response.ok) throw new Error('preload');
+      }
+      setPreloadStatus({
+        message: `Queued ${selectedProgramIds.length} program${
+          selectedProgramIds.length === 1 ? '' : 's'
+        } for ${selectedUser.full_name || selectedUser.username || 'this user'}.`,
+        error: '',
+      });
+      setSelectedProgramIds([]);
+    } catch (_error) {
+      setPreloadStatus({
+        message: '',
+        error: 'Unable to preload programs. Please try again.',
+      });
+    } finally {
+      setPreloadingPrograms(false);
+    }
+  };
+
+  if (loadingMe) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface-alt text-ink-muted">
+        Loading role manager…
       </div>
-      <table className="w-full border mt-4">
-        <thead>
-          <tr className="text-left border-b">
-            <th className="p-2">Name</th>
-            <th className="p-2">Username</th>
-            {ALL_ROLES.map(r => (
-              <th key={r} className="p-2">{r}</th>
+    );
+  }
+
+  if (generalError && !currentUser) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface-alt px-4">
+        <div className="panel max-w-md p-6 text-center">
+          <h1 className="text-lg font-semibold text-ink">Something went wrong</h1>
+          <p className="mt-2 text-sm text-ink-muted">{generalError}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (currentUser && !canManage) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-surface-alt px-4">
+        <div className="panel max-w-md p-6 text-center">
+          <h1 className="text-lg font-semibold text-ink">Access denied</h1>
+          <p className="mt-2 text-sm text-ink-muted">
+            You need an admin or manager role to manage team permissions.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const errors = [usersError, programsError].filter(Boolean);
+
+  return (
+    <div className="min-h-screen bg-surface-alt text-ink">
+      <div className="mx-auto max-w-6xl space-y-6 px-4 py-6">
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold">Role &amp; Program Manager</h1>
+            <p className="text-sm text-ink-muted">
+              Manage permissions and preload programs for your team.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <a href="/admin/users" className="btn btn-outline text-sm">
+              Users
+            </a>
+            <a href="/admin/roles" className="btn btn-primary text-sm">
+              Roles &amp; Programs
+            </a>
+            <a href="/programs" className="btn btn-outline text-sm">
+              Programs
+            </a>
+            <a href="/programs?tab=templates" className="btn btn-outline text-sm">
+              Templates
+            </a>
+          </div>
+        </header>
+
+        {errors.length > 0 && (
+          <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            {errors.map((msg, idx) => (
+              <p key={idx} className={idx > 0 ? 'mt-1' : undefined}>
+                {msg}
+              </p>
             ))}
-          </tr>
-        </thead>
-        <tbody>
-          {users.map(u => (
-            <tr key={u.id} className="border-b">
-              <td className="p-2">{u.full_name || ''}</td>
-              <td className="p-2">{u.username || ''}</td>
-              {ALL_ROLES.map(r => (
-                <td key={r} className="p-2 text-center">
-                  <input
-                    type="checkbox"
-                    checked={u.roles.includes(r)}
-                    onChange={() => toggleRole(u.id, r)}
-                    disabled={managerOnly && !MANAGER_EDITABLE_ROLES.includes(r)}
-                  />
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      {msg && <div className="text-sm text-green-600">{msg}</div>}
-      {err && <div className="text-sm text-red-600">{err}</div>}
-      <button className="btn btn-primary" onClick={handleSave}>Save</button>
+          </div>
+        )}
+
+        <section className="panel p-6 space-y-6">
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="min-w-[240px] flex-1 space-y-2">
+              <label className="label-text" htmlFor="role-manager-search">
+                Find user
+              </label>
+              <input
+                id="role-manager-search"
+                className="form-field"
+                type="search"
+                placeholder="Search by name or username…"
+                value={query}
+                onChange={event => setQuery(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <span className="label-text">Selected user</span>
+              <div className="text-sm font-medium">
+                {selectedUser
+                  ? `${selectedUser.full_name || selectedUser.username || '—'}${
+                      selectedUser.username ? ` (${selectedUser.username})` : ''
+                    }`
+                  : '—'}
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="btn btn-outline"
+                onClick={handleRefreshUsers}
+                disabled={usersLoading}
+              >
+                {usersLoading ? 'Refreshing…' : 'Refresh'}
+              </button>
+            </div>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="panel-section overflow-hidden">
+              <div className="max-h-[26rem] overflow-y-auto">
+                {usersLoading && !users.length ? (
+                  <div className="px-4 py-6 text-sm text-ink-muted">Loading users…</div>
+                ) : filteredUsers.length ? (
+                  filteredUsers.map(user => {
+                    const isActive = user.id === selectedUserId;
+                    return (
+                      <button
+                        key={user.id}
+                        type="button"
+                        onClick={() => setSelectedUserId(user.id)}
+                        className={`flex w-full flex-col gap-1 border-b border-border/60 px-4 py-3 text-left text-sm transition-colors last:border-b-0 ${
+                          isActive
+                            ? 'border-l-4 border-brand-primary bg-surface font-semibold shadow-sm'
+                            : 'hover:bg-surface'
+                        }`}
+                      >
+                        <span>{user.full_name || user.username || '—'}</span>
+                        <span className="text-xs text-ink-muted">
+                          {user.username || user.email || '—'}
+                        </span>
+                        <span className="text-xs text-ink-muted">
+                          Roles: {user.roles && user.roles.length ? user.roles.join(', ') : 'None assigned'}
+                        </span>
+                      </button>
+                    );
+                  })
+                ) : (
+                  <div className="px-4 py-6 text-sm text-ink-muted">
+                    {query ? 'No users match your search.' : 'No users available.'}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <div className="panel-section space-y-4 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h2 className="text-sm font-semibold">Roles</h2>
+                    <p className="mt-1 text-xs text-ink-muted">
+                      {managerOnly
+                        ? 'Managers can only toggle viewer or trainee roles.'
+                        : 'Select the roles to assign to this user.'}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="btn btn-primary"
+                    onClick={handleSaveRoles}
+                    disabled={!selectedUser || savingRoles || !hasRoleChanges}
+                  >
+                    {savingRoles ? 'Saving…' : 'Save roles'}
+                  </button>
+                </div>
+
+                {selectedUser ? (
+                  <div className="flex flex-wrap gap-3">
+                    {ALL_ROLES.map(role => {
+                      const disabled = managerOnly && !MANAGER_EDITABLE_ROLES.includes(role);
+                      return (
+                        <label
+                          key={role}
+                          className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
+                            disabled ? 'opacity-50' : ''
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            className="h-4 w-4 rounded border-border text-brand-primary focus:ring-focus"
+                            checked={roleDraft.includes(role)}
+                            onChange={() => handleToggleRole(role)}
+                            disabled={disabled}
+                          />
+                          <span className="capitalize">{role}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-ink-muted">
+                    Select a user to manage roles.
+                  </div>
+                )}
+
+                {rolesStatus.message && (
+                  <div className="text-sm text-brand-primary">{rolesStatus.message}</div>
+                )}
+                {rolesStatus.error && (
+                  <div className="text-sm text-red-600">{rolesStatus.error}</div>
+                )}
+              </div>
+
+              <div className="panel-section space-y-4 p-4">
+                <div>
+                  <h2 className="text-sm font-semibold">Preload programs</h2>
+                  <p className="mt-1 text-xs text-ink-muted">
+                    Queue programs for the selected user to start immediately.
+                  </p>
+                </div>
+                {programsLoading && !programs.length ? (
+                  <div className="text-sm text-ink-muted">Loading programs…</div>
+                ) : sortedPrograms.length ? (
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    {sortedPrograms.map(program => {
+                      const id = program.program_id || program.id;
+                      const label = program.title || program.name || id;
+                      return (
+                        <label
+                          key={id}
+                          className="inline-flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2 text-sm hover:bg-surface-alt"
+                        >
+                          <input
+                            type="checkbox"
+                            className="h-4 w-4 rounded border-border text-brand-primary focus:ring-focus"
+                            value={id}
+                            checked={selectedProgramIds.includes(id)}
+                            onChange={() => handleToggleProgram(id)}
+                            disabled={!selectedUser}
+                          />
+                          <span className="truncate" title={label}>
+                            {label}
+                          </span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-dashed border-border px-4 py-8 text-center text-sm text-ink-muted">
+                    No programs available to preload.
+                  </div>
+                )}
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    type="button"
+                    className="btn btn-outline"
+                    onClick={handlePreloadPrograms}
+                    disabled={
+                      !selectedUser ||
+                      !selectedProgramIds.length ||
+                      preloadingPrograms ||
+                      Boolean(programsError)
+                    }
+                  >
+                    {preloadingPrograms ? 'Preloading…' : 'Preload selected programs'}
+                  </button>
+                  {preloadStatus.message && (
+                    <span className="text-sm text-brand-primary">{preloadStatus.message}</span>
+                  )}
+                  {preloadStatus.error && (
+                    <span className="text-sm text-red-600">{preloadStatus.error}</span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }
@@ -105,6 +553,6 @@ if (typeof document !== 'undefined') {
   const rootEl = document.getElementById('root');
   if (rootEl) {
     const root = ReactDOM.createRoot(rootEl);
-    root.render(<RoleManager/>);
+    root.render(<RoleManager />);
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -21,24 +21,75 @@ body {
   color: var(--text-primary);
 }
 
-/* Card & table styles */
-.card {
-  @apply bg-white rounded-2xl shadow-sm border border-[var(--border)];
+@layer components {
+  /* Card & table styles */
+  .card {
+    @apply rounded-2xl border border-border bg-surface shadow-sm;
+  }
+
+  .card-header {
+    @apply border-b border-border p-4 font-semibold text-ink;
+  }
+
+  .table {
+    @apply w-full text-left;
+  }
+
+  .table th,
+  .table td {
+    @apply px-4 py-3;
+  }
+
+  .badge {
+    @apply inline-block rounded-full px-2 py-0.5 text-sm;
+  }
+
+  .badge-admin {
+    @apply bg-red-100 text-red-800;
+  }
+
+  .badge-manager {
+    @apply bg-blue-100 text-blue-800;
+  }
+
+  .badge-trainee {
+    @apply bg-green-100 text-green-800;
+  }
+
+  .badge-viewer {
+    @apply bg-gray-100 text-gray-800;
+  }
+
+  .panel {
+    @apply rounded-2xl border border-border bg-surface shadow-sm;
+  }
+
+  .panel-section {
+    @apply rounded-xl border border-border bg-surface-alt;
+  }
+
+  .label-text {
+    @apply block text-xs font-semibold uppercase tracking-wide text-ink-muted;
+  }
+
+  .form-field,
+  .input {
+    @apply w-full rounded-xl border border-border bg-surface px-3 py-2 text-sm text-ink transition-colors placeholder:text-ink-muted focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 focus:ring-offset-surface;
+  }
+
+  .btn {
+    @apply inline-flex items-center justify-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60;
+  }
+
+  .btn-primary {
+    @apply border-brand-primary bg-brand-primary text-white hover:bg-brand-accent;
+  }
+
+  .btn-outline {
+    @apply border-border bg-surface text-ink hover:bg-surface-alt;
+  }
+
+  .btn-ghost {
+    @apply border-transparent text-ink-muted hover:bg-surface-alt hover:text-ink;
+  }
 }
-.card-header {
-  @apply p-4 border-b border-[var(--border)] font-semibold;
-}
-.table {
-  @apply w-full text-left;
-}
-.table th,
-.table td {
-  @apply px-4 py-3;
-}
-.badge {
-  @apply inline-block rounded-full px-2 py-0.5 text-sm;
-}
-.badge-admin { @apply bg-red-100 text-red-800; }
-.badge-manager { @apply bg-blue-100 text-blue-800; }
-.badge-trainee { @apply bg-green-100 text-green-800; }
-.badge-viewer { @apply bg-gray-100 text-gray-800; }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,30 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./index.html', './public/**/*.{html,js}', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          primary: 'var(--brand-primary)',
+          accent: 'var(--brand-accent)',
+        },
+        ink: {
+          DEFAULT: 'var(--text-primary)',
+          muted: 'var(--text-muted)',
+        },
+        surface: {
+          DEFAULT: 'var(--surface)',
+          alt: 'var(--surface-alt)',
+        },
+        border: {
+          DEFAULT: 'var(--border)',
+        },
+        focus: 'var(--focus-ring)',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- rebuild the admin role manager with searchable user list, role drafting, and program preloading that honour admin/manager restrictions
- add Tailwind color aliases that mirror the shared CSS variables and introduce reusable panel/button/form utilities
- document the new utilities so future contributors reuse the shared tokens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9383387d0832c8fbe029b25fa6518