### PR TITLE
Align program actions with delete verb

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -86,8 +86,11 @@ export const publishProgram = (id: string) =>
 export const deprecateProgram = (id: string) =>
   apiFetch(`/api/programs/${id}/deprecate`, { method: 'POST' });
 
-export const archiveProgram = (id: string) =>
-  apiFetch(`/api/programs/${id}/archive`, { method: 'POST' });
+export const deleteProgram = (id: string) =>
+  apiFetch(`/api/programs/${id}`, { method: 'DELETE' });
+
+export const restoreProgram = (id: string) =>
+  apiFetch(`/api/programs/${id}/restore`, { method: 'POST' });
 
 export const cloneProgram = (id: string) =>
   apiFetch<Program>(`/api/programs/${id}/clone`, { method: 'POST' });
@@ -101,8 +104,11 @@ export const createTemplate = (payload: any) =>
 export const patchTemplate = (id: string, payload: any) =>
   apiFetch(`/api/templates/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
 
-export const archiveTemplate = (id: string) =>
-  apiFetch(`/api/templates/${id}/archive`, { method: 'POST' });
+export const deleteTemplate = (programId: string, templateId: string) =>
+  apiFetch(`/api/programs/${programId}/templates/${templateId}`, { method: 'DELETE' });
+
+export const restoreTemplate = (programId: string, templateId: string) =>
+  apiFetch(`/api/programs/${programId}/templates/${templateId}/restore`, { method: 'POST' });
 
 export const bulkAssign = (
   assignments: { userId: string; programId: string; startDate: string; dueDate: string }[],
@@ -124,6 +130,14 @@ async function mockFetch<T>(url: string, opts?: RequestInit): Promise<T> {
       return { ...opts?.body && JSON.parse(opts.body.toString()), id: 'u-new' } as any;
     case url.startsWith('/api/programs?'):
       return { data: p, meta: { total: p.length, page: 1 } } as any;
+    case /^\/api\/programs\/[^/]+$/.test(url) && opts?.method === 'DELETE':
+      return { deleted: true } as any;
+    case /^\/api\/programs\/[^/]+\/restore$/.test(url) && opts?.method === 'POST':
+      return { restored: true } as any;
+    case /^\/api\/programs\/[^/]+\/templates\/[^/]+$/.test(url) && opts?.method === 'DELETE':
+      return { deleted: true } as any;
+    case /^\/api\/programs\/[^/]+\/templates\/[^/]+\/restore$/.test(url) && opts?.method === 'POST':
+      return { restored: true } as any;
     case url.startsWith('/api/audit'):
       return seed.audit as any;
     default:

--- a/src/programs/ProgramsLanding.tsx
+++ b/src/programs/ProgramsLanding.tsx
@@ -4,7 +4,8 @@ import {
   createProgram,
   publishProgram,
   deprecateProgram,
-  archiveProgram,
+  deleteProgram,
+  restoreProgram,
   getTemplates,
 } from '../api';
 import { can, User } from '../rbac';
@@ -116,9 +117,14 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
                       Deprecate
                     </button>
                   )}
-                  {can(currentUser, 'archive', 'program') && (
-                    <button className="underline" onClick={() => archiveProgram(p.id)}>
-                      Archive
+                  {can(currentUser, 'delete', 'program') && p.status !== 'archived' && (
+                    <button className="underline" onClick={() => deleteProgram(p.id)}>
+                      Delete
+                    </button>
+                  )}
+                  {can(currentUser, 'delete', 'program') && p.status === 'archived' && (
+                    <button className="underline" onClick={() => restoreProgram(p.id)}>
+                      Restore
                     </button>
                   )}
                 </div>
@@ -151,8 +157,8 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
                   {can(currentUser, 'update', 'template') && (
                     <button className="underline">Edit</button>
                   )}
-                  {can(currentUser, 'archive', 'template') && (
-                    <button className="underline">Archive</button>
+                  {can(currentUser, 'delete', 'template') && (
+                    <button className="underline">Delete</button>
                   )}
                 </div>
               }

--- a/src/rbac.ts
+++ b/src/rbac.ts
@@ -29,14 +29,14 @@ const policy: Record<string, Record<string, Role[]>> = {
     update: ['admin', 'manager'],
     publish: ['admin', 'manager'],
     deprecate: ['admin', 'manager'],
-    archive: ['admin'],
+    delete: ['admin'],
     assignToUser: ['admin', 'manager'],
   },
   template: {
     create: ['admin', 'manager'],
     read: ['admin', 'manager', 'viewer', 'trainee'],
     update: ['admin', 'manager'],
-    archive: ['admin', 'manager'],
+    delete: ['admin', 'manager'],
   },
 };
 


### PR DESCRIPTION
## Summary
- update RBAC policy and UI can() checks to use the unified `delete` action for programs and templates
- switch program API helpers and UI buttons to hit the DELETE and restore routes and expand mock responses accordingly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c94100a21c832ca476938d369e445f