### PR TITLE
Add admin program and template manager page

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -1,0 +1,298 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>ANX • Program &amp; Template Manager</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { theme: { extend: { colors: { anx: { sky: '#0ea5e9' }}}}};
+  </script>
+  <style>
+    :root {
+      color-scheme: light;
+      --surface: #ffffff;
+      --surface-alt: #f8fafc;
+      --border: #e2e8f0;
+      --ink: #0f172a;
+      --ink-muted: #64748b;
+      --brand-primary: #2563eb;
+      --brand-accent: #7c3aed;
+    }
+
+    body {
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background-color: var(--surface-alt);
+      color: var(--ink);
+    }
+
+    .panel {
+      border-radius: 1rem;
+      border: 1px solid var(--border);
+      background-color: var(--surface);
+      box-shadow: 0 10px 25px -12px rgba(15, 23, 42, 0.35);
+    }
+
+    .panel-section {
+      border-radius: 0.75rem;
+      border: 1px solid var(--border);
+      background-color: var(--surface);
+    }
+
+    .label-text {
+      display: block;
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--ink-muted);
+    }
+
+    .input {
+      width: 100%;
+      border-radius: 0.75rem;
+      border: 1px solid var(--border);
+      background-color: var(--surface);
+      padding: 0.5rem 0.75rem;
+      font-size: 0.875rem;
+      color: var(--ink);
+      transition: box-shadow 0.15s ease, border-color 0.15s ease;
+    }
+
+    .input:focus {
+      outline: none;
+      border-color: var(--brand-primary);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      border-radius: 0.75rem;
+      border: 1px solid var(--border);
+      background-color: var(--surface);
+      padding: 0.5rem 0.85rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--ink);
+      transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+      cursor: pointer;
+    }
+
+    .btn-primary {
+      border-color: var(--brand-primary);
+      background-color: var(--brand-primary);
+      color: #fff;
+    }
+
+    .btn-primary:hover {
+      border-color: var(--brand-accent);
+      background-color: var(--brand-accent);
+    }
+
+    .btn-outline {
+      border-color: var(--border);
+      background-color: var(--surface);
+      color: var(--ink);
+    }
+
+    .btn-outline:hover {
+      background-color: var(--surface-alt);
+    }
+
+    .btn-ghost {
+      border-color: transparent;
+      background-color: transparent;
+      color: var(--ink-muted);
+    }
+
+    .btn-ghost:hover {
+      background-color: var(--surface-alt);
+      color: var(--ink);
+    }
+
+    .btn:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+
+    .table {
+      width: 100%;
+      border-collapse: collapse;
+      text-align: left;
+    }
+
+    .table th,
+    .table td {
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.875rem;
+    }
+
+    .table tbody tr:hover {
+      background-color: var(--surface-alt);
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .badge-published {
+      background-color: rgba(34, 197, 94, 0.18);
+      color: #15803d;
+    }
+
+    .badge-draft {
+      background-color: rgba(59, 130, 246, 0.18);
+      color: #1d4ed8;
+    }
+
+    .badge-deprecated {
+      background-color: rgba(251, 191, 36, 0.24);
+      color: #b45309;
+    }
+
+    .badge-archived {
+      background-color: rgba(148, 163, 184, 0.25);
+      color: #475569;
+    }
+
+    .empty-row td {
+      text-align: center;
+      padding: 2.5rem 1rem;
+      color: var(--ink-muted);
+      font-size: 0.875rem;
+    }
+  </style>
+</head>
+<body class="bg-slate-50 text-slate-900">
+  <div class="max-w-6xl mx-auto p-4 space-y-6">
+    <header class="flex items-center justify-between gap-4 flex-wrap">
+      <div>
+        <h1 class="text-2xl font-bold">Program &amp; Template Manager</h1>
+        <p class="text-sm text-slate-500">Coordinate program lifecycles and fine-tune reusable templates.</p>
+      </div>
+      <div class="flex items-center gap-3 flex-wrap justify-end">
+        <div class="flex flex-wrap gap-2">
+          <a href="/admin/user-manager" class="btn btn-outline text-sm">Users</a>
+          <a href="/admin/role-manager.html" class="btn btn-outline text-sm">Roles &amp; Programs</a>
+          <a href="/admin/program-template-manager.html" class="btn btn-primary text-sm">Program Templates</a>
+          <a href="/programs" class="btn btn-outline text-sm">Programs</a>
+          <a href="/programs?tab=templates" class="btn btn-outline text-sm">Templates</a>
+        </div>
+        <a href="/" class="text-sm text-anx-sky underline">← Back to Orientation</a>
+      </div>
+    </header>
+
+    <section class="panel p-4 md:p-6 space-y-4" id="programSection">
+      <div class="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <h2 class="text-xl font-semibold">Programs</h2>
+          <p class="text-sm text-slate-500">Select programs to publish, deprecate, archive, or restore.</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <button id="btnRefreshPrograms" class="btn btn-outline text-sm">Refresh</button>
+        </div>
+      </div>
+
+      <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <label class="space-y-1">
+          <span class="label-text">Search programs</span>
+          <input id="programSearch" class="input" placeholder="Search by name, status, or owner…">
+        </label>
+        <div id="programSelectionSummary" class="text-xs text-slate-500 md:text-right">No programs selected.</div>
+      </div>
+
+      <div class="panel-section overflow-hidden">
+        <div class="overflow-x-auto">
+          <table class="table min-w-full" id="programTable">
+            <thead class="bg-slate-100 text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th class="w-10">
+                  <input type="checkbox" id="programSelectAll" class="rounded border-slate-300">
+                </th>
+                <th>Name</th>
+                <th>Status</th>
+                <th>Version</th>
+                <th>Owner</th>
+                <th>Updated</th>
+                <th class="text-right">Assigned</th>
+              </tr>
+            </thead>
+            <tbody id="programTableBody" class="bg-white text-sm"></tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="space-y-1">
+        <div class="flex flex-wrap gap-2" id="programActions">
+          <button class="btn btn-primary" data-program-action="publish">Publish</button>
+          <button class="btn btn-outline" data-program-action="deprecate">Deprecate</button>
+          <button class="btn btn-outline" data-program-action="archive">Archive</button>
+          <button class="btn btn-outline" data-program-action="restore">Restore</button>
+        </div>
+        <div id="programActionHint" class="text-xs text-slate-500">Select one or more programs to enable lifecycle actions.</div>
+        <div id="programMessage" class="text-xs text-slate-500"></div>
+      </div>
+    </section>
+
+    <section class="panel p-4 md:p-6 space-y-4" id="templateSection">
+      <div class="flex items-start justify-between gap-3 flex-wrap">
+        <div>
+          <h2 class="text-xl font-semibold">Templates</h2>
+          <p class="text-sm text-slate-500">Update template readiness before assigning to programs.</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <button id="btnRefreshTemplates" class="btn btn-outline text-sm">Refresh</button>
+        </div>
+      </div>
+
+      <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+        <label class="space-y-1">
+          <span class="label-text">Search templates</span>
+          <input id="templateSearch" class="input" placeholder="Search by name, status, or category…">
+        </label>
+        <div id="templateSelectionSummary" class="text-xs text-slate-500 md:text-right">No templates selected.</div>
+      </div>
+
+      <div class="panel-section overflow-hidden">
+        <div class="overflow-x-auto">
+          <table class="table min-w-full" id="templateTable">
+            <thead class="bg-slate-100 text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th class="w-10">
+                  <input type="checkbox" id="templateSelectAll" class="rounded border-slate-300">
+                </th>
+                <th>Name</th>
+                <th>Category</th>
+                <th>Status</th>
+                <th>Updated</th>
+              </tr>
+            </thead>
+            <tbody id="templateTableBody" class="bg-white text-sm"></tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="space-y-1">
+        <div class="flex flex-wrap gap-2" id="templateActions">
+          <button class="btn btn-primary" data-template-action="publish">Publish</button>
+          <button class="btn btn-outline" data-template-action="draft">Mark Draft</button>
+          <button class="btn btn-outline" data-template-action="deprecate">Deprecate</button>
+        </div>
+        <div id="templateActionHint" class="text-xs text-slate-500">Select one or more templates to enable status changes.</div>
+        <div id="templateMessage" class="text-xs text-slate-500"></div>
+      </div>
+    </section>
+  </div>
+
+  <script type="module" src="./program-template-manager.js"></script>
+</body>
+</html>

--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -1,0 +1,513 @@
+const API = window.location.origin;
+
+async function fetchJson(url, options = {}) {
+  const res = await fetch(url, { credentials: 'include', ...options });
+  if (res.status === 204) return null;
+  if (!res.ok) {
+    const err = new Error(`${options.method || 'GET'} ${url} failed (${res.status})`);
+    err.status = res.status;
+    throw err;
+  }
+  const ct = res.headers.get('content-type') || '';
+  if (ct.includes('application/json')) {
+    return res.json();
+  }
+  return res.text();
+}
+
+function createStatusBadge(status) {
+  const normalized = (status || '').toLowerCase();
+  const badgeClass = {
+    published: 'badge badge-published',
+    draft: 'badge badge-draft',
+    deprecated: 'badge badge-deprecated',
+    archived: 'badge badge-archived',
+  }[normalized] || 'badge badge-draft';
+  const label = normalized ? normalized.charAt(0).toUpperCase() + normalized.slice(1) : '—';
+  return `<span class="${badgeClass}">${label}</span>`;
+}
+
+function formatDate(dateLike) {
+  if (!dateLike) return '—';
+  const d = new Date(dateLike);
+  if (Number.isNaN(d.getTime())) return dateLike;
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+const meResponse = await fetch(`${API}/me`, { credentials: 'include' });
+if (!meResponse.ok) {
+  window.location.href = '/';
+  throw new Error('Unauthorized');
+}
+const me = await meResponse.json();
+const roles = Array.isArray(me?.roles) ? me.roles : [];
+const IS_ADMIN = roles.includes('admin');
+const IS_MANAGER = roles.includes('manager');
+const CAN_MANAGE_PROGRAMS = IS_ADMIN || IS_MANAGER;
+const CAN_MANAGE_TEMPLATES = IS_ADMIN || IS_MANAGER;
+const ADMIN_ONLY_PROGRAM_ACTIONS = new Set(['archive', 'restore']);
+
+const programTableBody = document.getElementById('programTableBody');
+const templateTableBody = document.getElementById('templateTableBody');
+const programSearchInput = document.getElementById('programSearch');
+const templateSearchInput = document.getElementById('templateSearch');
+const programMessage = document.getElementById('programMessage');
+const templateMessage = document.getElementById('templateMessage');
+const programSelectionSummary = document.getElementById('programSelectionSummary');
+const templateSelectionSummary = document.getElementById('templateSelectionSummary');
+const programSelectAll = document.getElementById('programSelectAll');
+const templateSelectAll = document.getElementById('templateSelectAll');
+const programActionHint = document.getElementById('programActionHint');
+const templateActionHint = document.getElementById('templateActionHint');
+const programActionsContainer = document.getElementById('programActions');
+const templateActionsContainer = document.getElementById('templateActions');
+const btnRefreshPrograms = document.getElementById('btnRefreshPrograms');
+const btnRefreshTemplates = document.getElementById('btnRefreshTemplates');
+
+if (!programTableBody || !templateTableBody || !programActionsContainer || !templateActionsContainer) {
+  throw new Error('Program & Template Manager: required DOM nodes are missing.');
+}
+
+let programs = [];
+let templates = [];
+const selectedProgramIds = new Set();
+const selectedTemplateIds = new Set();
+
+if (!CAN_MANAGE_PROGRAMS) {
+  programActionHint.textContent = 'You have read-only access. Only admins or managers can change program lifecycles.';
+  if (programSelectAll) programSelectAll.disabled = true;
+}
+if (!CAN_MANAGE_TEMPLATES) {
+  templateActionHint.textContent = 'You have read-only access. Only admins or managers can change template statuses.';
+  if (templateSelectAll) templateSelectAll.disabled = true;
+}
+
+function getFilteredPrograms() {
+  const term = (programSearchInput?.value || '').trim().toLowerCase();
+  if (!term) return [...programs];
+  return programs.filter(p => {
+    return [p.name, p.status, p.owner, p.version]
+      .filter(Boolean)
+      .some(value => value.toString().toLowerCase().includes(term));
+  });
+}
+
+function getFilteredTemplates() {
+  const term = (templateSearchInput?.value || '').trim().toLowerCase();
+  if (!term) return [...templates];
+  return templates.filter(t => {
+    return [t.name, t.status, t.category]
+      .filter(Boolean)
+      .some(value => value.toString().toLowerCase().includes(term));
+  });
+}
+
+function syncProgramSelection() {
+  const validIds = new Set(programs.map(p => p.id));
+  for (const id of Array.from(selectedProgramIds)) {
+    if (!validIds.has(id)) selectedProgramIds.delete(id);
+  }
+}
+
+function syncTemplateSelection() {
+  const validIds = new Set(templates.map(t => t.id));
+  for (const id of Array.from(selectedTemplateIds)) {
+    if (!validIds.has(id)) selectedTemplateIds.delete(id);
+  }
+}
+
+function updateProgramActionsState(displayedPrograms) {
+  const hasSelection = selectedProgramIds.size > 0;
+  programActionsContainer.querySelectorAll('button[data-program-action]').forEach(btn => {
+    const action = btn.dataset.programAction;
+    if (!CAN_MANAGE_PROGRAMS) {
+      btn.disabled = true;
+      btn.title = 'Only admins or managers can perform this action.';
+      return;
+    }
+    if (ADMIN_ONLY_PROGRAM_ACTIONS.has(action) && !IS_ADMIN) {
+      btn.disabled = true;
+      btn.title = 'Only admins can archive or restore programs.';
+      return;
+    }
+    btn.disabled = !hasSelection;
+    btn.title = hasSelection ? '' : 'Select at least one program.';
+  });
+  if (programSelectAll) {
+    const countDisplayed = displayedPrograms.length;
+    const allSelected = countDisplayed > 0 && displayedPrograms.every(p => selectedProgramIds.has(p.id));
+    const someSelected = displayedPrograms.some(p => selectedProgramIds.has(p.id));
+    programSelectAll.disabled = !CAN_MANAGE_PROGRAMS || countDisplayed === 0;
+    programSelectAll.checked = allSelected;
+    programSelectAll.indeterminate = !allSelected && someSelected;
+  }
+}
+
+function updateTemplateActionsState(displayedTemplates) {
+  const hasSelection = selectedTemplateIds.size > 0;
+  templateActionsContainer.querySelectorAll('button[data-template-action]').forEach(btn => {
+    if (!CAN_MANAGE_TEMPLATES) {
+      btn.disabled = true;
+      btn.title = 'Only admins or managers can perform this action.';
+      return;
+    }
+    btn.disabled = !hasSelection;
+    btn.title = hasSelection ? '' : 'Select at least one template.';
+  });
+  if (templateSelectAll) {
+    const countDisplayed = displayedTemplates.length;
+    const allSelected = countDisplayed > 0 && displayedTemplates.every(t => selectedTemplateIds.has(t.id));
+    const someSelected = displayedTemplates.some(t => selectedTemplateIds.has(t.id));
+    templateSelectAll.disabled = !CAN_MANAGE_TEMPLATES || countDisplayed === 0;
+    templateSelectAll.checked = allSelected;
+    templateSelectAll.indeterminate = !allSelected && someSelected;
+  }
+}
+
+function updateProgramSelectionSummary() {
+  if (!CAN_MANAGE_PROGRAMS) {
+    programSelectionSummary.textContent = 'Read-only mode — program actions are disabled for your role.';
+    return;
+  }
+  const count = selectedProgramIds.size;
+  programSelectionSummary.textContent = count
+    ? `${count} program${count > 1 ? 's' : ''} selected.`
+    : 'No programs selected.';
+}
+
+function updateTemplateSelectionSummary() {
+  if (!CAN_MANAGE_TEMPLATES) {
+    templateSelectionSummary.textContent = 'Read-only mode — template actions are disabled for your role.';
+    return;
+  }
+  const count = selectedTemplateIds.size;
+  templateSelectionSummary.textContent = count
+    ? `${count} template${count > 1 ? 's' : ''} selected.`
+    : 'No templates selected.';
+}
+
+function renderPrograms() {
+  syncProgramSelection();
+  const displayed = getFilteredPrograms();
+  if (!displayed.length) {
+    programTableBody.innerHTML = '<tr class="empty-row"><td colspan="7">No programs found.</td></tr>';
+  } else {
+    programTableBody.innerHTML = displayed.map(program => {
+      const disabledAttr = CAN_MANAGE_PROGRAMS ? '' : 'disabled';
+      const checkedAttr = selectedProgramIds.has(program.id) ? 'checked' : '';
+      const assigned = typeof program.assignedCount === 'number' ? program.assignedCount : '—';
+      return `
+        <tr data-program-id="${program.id}">
+          <td><input type="checkbox" data-program-id="${program.id}" ${checkedAttr} ${disabledAttr} class="rounded border-slate-300"></td>
+          <td class="font-medium">${program.name || '—'}</td>
+          <td>${createStatusBadge(program.status)}</td>
+          <td>${program.version || '—'}</td>
+          <td>${program.owner || '—'}</td>
+          <td>${formatDate(program.updatedAt)}</td>
+          <td class="text-right">${assigned}</td>
+        </tr>
+      `;
+    }).join('');
+  }
+  updateProgramSelectionSummary();
+  updateProgramActionsState(displayed);
+}
+
+function renderTemplates() {
+  syncTemplateSelection();
+  const displayed = getFilteredTemplates();
+  if (!displayed.length) {
+    templateTableBody.innerHTML = '<tr class="empty-row"><td colspan="5">No templates found.</td></tr>';
+  } else {
+    templateTableBody.innerHTML = displayed.map(template => {
+      const disabledAttr = CAN_MANAGE_TEMPLATES ? '' : 'disabled';
+      const checkedAttr = selectedTemplateIds.has(template.id) ? 'checked' : '';
+      return `
+        <tr data-template-id="${template.id}">
+          <td><input type="checkbox" data-template-id="${template.id}" ${checkedAttr} ${disabledAttr} class="rounded border-slate-300"></td>
+          <td class="font-medium">${template.name || '—'}</td>
+          <td>${template.category || '—'}</td>
+          <td>${createStatusBadge(template.status)}</td>
+          <td>${formatDate(template.updatedAt)}</td>
+        </tr>
+      `;
+    }).join('');
+  }
+  updateTemplateSelectionSummary();
+  updateTemplateActionsState(displayed);
+}
+
+async function loadPrograms() {
+  try {
+    programMessage.textContent = 'Loading programs…';
+    const data = await fetchJson(`${API}/api/programs?status=all`);
+    if (Array.isArray(data?.data)) {
+      programs = data.data;
+    } else if (Array.isArray(data)) {
+      programs = data;
+    } else {
+      programs = [];
+    }
+    selectedProgramIds.clear();
+    renderPrograms();
+    programMessage.textContent = '';
+  } catch (error) {
+    console.error(error);
+    programs = [];
+    selectedProgramIds.clear();
+    renderPrograms();
+    if (error.status === 403) {
+      programMessage.textContent = 'You do not have permission to load programs.';
+    } else {
+      programMessage.textContent = 'Unable to load programs. Please try again later.';
+    }
+  }
+}
+
+async function loadTemplates() {
+  try {
+    templateMessage.textContent = 'Loading templates…';
+    const data = await fetchJson(`${API}/api/templates?scope=all`);
+    if (Array.isArray(data?.data)) {
+      templates = data.data;
+    } else if (Array.isArray(data)) {
+      templates = data;
+    } else {
+      templates = [];
+    }
+    selectedTemplateIds.clear();
+    renderTemplates();
+    templateMessage.textContent = '';
+  } catch (error) {
+    console.error(error);
+    templates = [];
+    selectedTemplateIds.clear();
+    renderTemplates();
+    if (error.status === 403) {
+      templateMessage.textContent = 'You do not have permission to load templates.';
+    } else {
+      templateMessage.textContent = 'Unable to load templates. Please try again later.';
+    }
+  }
+}
+
+function getProgramActionRequest(action, id) {
+  const encoded = encodeURIComponent(id);
+  switch (action) {
+    case 'publish':
+      return { url: `${API}/api/programs/${encoded}/publish`, options: { method: 'POST', credentials: 'include' } };
+    case 'deprecate':
+      return { url: `${API}/api/programs/${encoded}/deprecate`, options: { method: 'POST', credentials: 'include' } };
+    case 'archive':
+      return { url: `${API}/api/programs/${encoded}/archive`, options: { method: 'POST', credentials: 'include' } };
+    case 'restore':
+      return { url: `${API}/api/programs/${encoded}/restore`, options: { method: 'POST', credentials: 'include' } };
+    default:
+      return null;
+  }
+}
+
+const programActionLabels = {
+  publish: 'Publish',
+  deprecate: 'Deprecate',
+  archive: 'Archive',
+  restore: 'Restore',
+};
+
+async function handleProgramAction(action) {
+  if (!CAN_MANAGE_PROGRAMS) return;
+  if (ADMIN_ONLY_PROGRAM_ACTIONS.has(action) && !IS_ADMIN) return;
+  if (!selectedProgramIds.size) {
+    programMessage.textContent = 'Select at least one program first.';
+    return;
+  }
+  const label = programActionLabels[action] || 'Update';
+  programMessage.textContent = `${label} in progress…`;
+  const ids = Array.from(selectedProgramIds);
+  let success = 0;
+  let failure = 0;
+  for (const id of ids) {
+    const request = getProgramActionRequest(action, id);
+    if (!request) continue;
+    try {
+      const res = await fetch(request.url, request.options);
+      if (res.ok) {
+        success += 1;
+      } else {
+        failure += 1;
+      }
+    } catch (error) {
+      console.error(error);
+      failure += 1;
+    }
+  }
+  await loadPrograms();
+  programMessage.textContent = `${label} complete — ${success} succeeded, ${failure} failed.`;
+}
+
+const templateActionLabels = {
+  publish: 'Publish',
+  draft: 'Mark draft',
+  deprecate: 'Deprecate',
+};
+
+function getTemplatePayload(action) {
+  switch (action) {
+    case 'publish':
+      return { status: 'published' };
+    case 'draft':
+      return { status: 'draft' };
+    case 'deprecate':
+      return { status: 'deprecated' };
+    default:
+      return null;
+  }
+}
+
+async function handleTemplateAction(action) {
+  if (!CAN_MANAGE_TEMPLATES) return;
+  if (!selectedTemplateIds.size) {
+    templateMessage.textContent = 'Select at least one template first.';
+    return;
+  }
+  const payload = getTemplatePayload(action);
+  if (!payload) return;
+  const label = templateActionLabels[action] || 'Update';
+  templateMessage.textContent = `${label} in progress…`;
+  const ids = Array.from(selectedTemplateIds);
+  let success = 0;
+  let failure = 0;
+  for (const id of ids) {
+    try {
+      const res = await fetch(`${API}/api/templates/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        success += 1;
+      } else {
+        failure += 1;
+      }
+    } catch (error) {
+      console.error(error);
+      failure += 1;
+    }
+  }
+  await loadTemplates();
+  templateMessage.textContent = `${label} complete — ${success} succeeded, ${failure} failed.`;
+}
+
+programTableBody.addEventListener('change', event => {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement)) return;
+  const id = target.getAttribute('data-program-id');
+  if (!id) return;
+  if (!CAN_MANAGE_PROGRAMS) {
+    target.checked = false;
+    return;
+  }
+  if (target.checked) {
+    selectedProgramIds.add(id);
+  } else {
+    selectedProgramIds.delete(id);
+  }
+  updateProgramSelectionSummary();
+  const displayed = getFilteredPrograms();
+  updateProgramActionsState(displayed);
+});
+
+templateTableBody.addEventListener('change', event => {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement)) return;
+  const id = target.getAttribute('data-template-id');
+  if (!id) return;
+  if (!CAN_MANAGE_TEMPLATES) {
+    target.checked = false;
+    return;
+  }
+  if (target.checked) {
+    selectedTemplateIds.add(id);
+  } else {
+    selectedTemplateIds.delete(id);
+  }
+  updateTemplateSelectionSummary();
+  const displayed = getFilteredTemplates();
+  updateTemplateActionsState(displayed);
+});
+
+if (programSearchInput) {
+  programSearchInput.addEventListener('input', () => {
+    renderPrograms();
+  });
+}
+
+if (templateSearchInput) {
+  templateSearchInput.addEventListener('input', () => {
+    renderTemplates();
+  });
+}
+
+if (programSelectAll) {
+  programSelectAll.addEventListener('change', () => {
+    if (!CAN_MANAGE_PROGRAMS) {
+      programSelectAll.checked = false;
+      return;
+    }
+    const displayed = getFilteredPrograms();
+    if (programSelectAll.checked) {
+      displayed.forEach(p => selectedProgramIds.add(p.id));
+    } else {
+      displayed.forEach(p => selectedProgramIds.delete(p.id));
+    }
+    renderPrograms();
+  });
+}
+
+if (templateSelectAll) {
+  templateSelectAll.addEventListener('change', () => {
+    if (!CAN_MANAGE_TEMPLATES) {
+      templateSelectAll.checked = false;
+      return;
+    }
+    const displayed = getFilteredTemplates();
+    if (templateSelectAll.checked) {
+      displayed.forEach(t => selectedTemplateIds.add(t.id));
+    } else {
+      displayed.forEach(t => selectedTemplateIds.delete(t.id));
+    }
+    renderTemplates();
+  });
+}
+
+programActionsContainer.addEventListener('click', event => {
+  const btn = event.target instanceof HTMLElement ? event.target.closest('button[data-program-action]') : null;
+  if (!btn) return;
+  const action = btn.dataset.programAction;
+  if (!action) return;
+  handleProgramAction(action);
+});
+
+templateActionsContainer.addEventListener('click', event => {
+  const btn = event.target instanceof HTMLElement ? event.target.closest('button[data-template-action]') : null;
+  if (!btn) return;
+  const action = btn.dataset.templateAction;
+  if (!action) return;
+  handleTemplateAction(action);
+});
+
+if (btnRefreshPrograms) {
+  btnRefreshPrograms.addEventListener('click', () => {
+    loadPrograms();
+  });
+}
+
+if (btnRefreshTemplates) {
+  btnRefreshTemplates.addEventListener('click', () => {
+    loadTemplates();
+  });
+}
+
+await loadPrograms();
+await loadTemplates();


### PR DESCRIPTION
## Summary
- add a new admin Program & Template Manager page with navigation updates, search inputs, and lifecycle action controls for programs and templates
- implement a companion module script to load program/template data, run lifecycle actions, and enforce admin/manager RBAC guards on interactive controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c948c83018832c95be062418f3492b