### PR TITLE
Align program and template APIs with server routes

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -16,6 +16,7 @@ export interface Program {
 
 export interface Template {
   id: string;
+  programId: string;
   name: string;
   category: string;
   updatedAt?: string;
@@ -23,6 +24,9 @@ export interface Template {
 }
 
 const useMock = true;
+
+const PROGRAMS_BASE = '/programs';
+const programTemplatesBase = (programId: string) => `${PROGRAMS_BASE}/${programId}/templates`;
 
 async function apiFetch<T>(url: string, opts?: RequestInit): Promise<T> {
   if (!useMock) {
@@ -77,16 +81,35 @@ export const getAuditLog = (userId: string) =>
   );
 
 /* ------------------- Programs & Templates ------------------- */
-export const getPrograms = (params: { status?: string; query?: string; page?: number }) =>
-  apiFetch<{ data: Program[]; meta: { total: number; page: number } }>(
-    `/api/programs?${new URLSearchParams(params as any)}`,
+type ProgramListResponse = { data: Program[]; meta: { total: number; page: number } };
+type TemplateListResponse = { data: Template[] };
+
+export const getPrograms = async (
+  params: { status?: string; query?: string; page?: number; includeDeleted?: boolean } = {},
+) => {
+  const search = new URLSearchParams();
+  if (params.status) search.set('status', params.status);
+  if (params.query) search.set('query', params.query);
+  if (typeof params.page === 'number') search.set('page', String(params.page));
+  if (params.includeDeleted) search.set('include_deleted', 'true');
+
+  const query = search.toString();
+  const result = await apiFetch<Program[] | ProgramListResponse>(
+    `${PROGRAMS_BASE}${query ? `?${query}` : ''}`,
   );
 
+  if (Array.isArray(result)) {
+    return { data: result, meta: { total: result.length, page: 1 } };
+  }
+
+  return result;
+};
+
 export const createProgram = (payload: Partial<Program>) =>
-  apiFetch<Program>('/api/programs', { method: 'POST', body: JSON.stringify(payload) });
+  apiFetch<Program>(PROGRAMS_BASE, { method: 'POST', body: JSON.stringify(payload) });
 
 export const patchProgram = (id: string, payload: Partial<Program>) =>
-  apiFetch<Program>(`/api/programs/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
+  apiFetch<Program>(`${PROGRAMS_BASE}/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
 
 export const publishProgram = (id: string) =>
   apiFetch(`/api/programs/${id}/publish`, { method: 'POST' });
@@ -98,28 +121,53 @@ export const archiveProgram = (id: string) =>
   apiFetch(`/api/programs/${id}/archive`, { method: 'POST' });
 
 export const deleteProgram = (id: string) =>
-  apiFetch(`/api/programs/${id}`, { method: 'DELETE' });
+  apiFetch(`${PROGRAMS_BASE}/${id}`, { method: 'DELETE' });
 
 export const restoreProgram = (id: string) =>
-  apiFetch(`/api/programs/${id}/restore`, { method: 'POST' });
+  apiFetch(`${PROGRAMS_BASE}/${id}/restore`, { method: 'POST' });
 
 export const cloneProgram = (id: string) =>
   apiFetch<Program>(`/api/programs/${id}/clone`, { method: 'POST' });
 
-export const getTemplates = (params: { query?: string; category?: string }) =>
-  apiFetch<{ data: Template[] }>(`/api/templates?${new URLSearchParams(params as any)}`);
+export const getProgramTemplates = async (
+  programId: string,
+  params: { includeDeleted?: boolean } = {},
+) => {
+  const search = new URLSearchParams();
+  if (params.includeDeleted) search.set('include_deleted', 'true');
+  const query = search.toString();
+  const result = await apiFetch<Template[] | TemplateListResponse>(
+    `${programTemplatesBase(programId)}${query ? `?${query}` : ''}`,
+  );
 
-export const createTemplate = (payload: Partial<Template>) =>
-  apiFetch<Template>('/api/templates', { method: 'POST', body: JSON.stringify(payload) });
+  if (Array.isArray(result)) {
+    return { data: result };
+  }
 
-export const patchTemplate = (id: string, payload: Partial<Template>) =>
-  apiFetch<Template>(`/api/templates/${id}`, { method: 'PATCH', body: JSON.stringify(payload) });
+  return result;
+};
+
+export const createTemplate = (programId: string, payload: Partial<Template>) =>
+  apiFetch<Template>(programTemplatesBase(programId), {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+
+export const patchTemplate = (
+  programId: string,
+  templateId: string,
+  payload: Partial<Template>,
+) =>
+  apiFetch<Template>(`${programTemplatesBase(programId)}/${templateId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
 
 export const deleteTemplate = (programId: string, templateId: string) =>
-  apiFetch(`/api/programs/${programId}/templates/${templateId}`, { method: 'DELETE' });
+  apiFetch(`${programTemplatesBase(programId)}/${templateId}`, { method: 'DELETE' });
 
 export const restoreTemplate = (programId: string, templateId: string) =>
-  apiFetch(`/api/programs/${programId}/templates/${templateId}/restore`, { method: 'POST' });
+  apiFetch(`${programTemplatesBase(programId)}/${templateId}/restore`, { method: 'POST' });
 
 export const bulkAssign = (
   assignments: { userId: string; programId: string; startDate: string; dueDate: string }[],
@@ -134,32 +182,68 @@ async function mockFetch<T>(url: string, opts?: RequestInit): Promise<T> {
   await new Promise(r => setTimeout(r, 300)); // simulate latency
   const u = seed.users;
   const p = seed.programs;
+  const method = (opts?.method || 'GET').toUpperCase();
   switch (true) {
     case url.startsWith('/api/users?'):
       return { data: u, meta: { total: u.length, page: 1 } } as any;
-    case url === '/api/users':
+    case url === '/api/users' && method === 'POST':
       return { ...opts?.body && JSON.parse(opts.body.toString()), id: 'u-new' } as any;
+    case (url === PROGRAMS_BASE || url.startsWith(`${PROGRAMS_BASE}?`)) && method === 'GET':
+      return { data: p, meta: { total: p.length, page: 1 } } as any;
+    case url === PROGRAMS_BASE && method === 'POST':
+      return { ...opts?.body && JSON.parse(opts.body.toString()), id: 'p-new' } as any;
+    case /^\/programs\/[^/]+$/.test(url) && method === 'PATCH':
+      return {
+        ...opts?.body && JSON.parse(opts.body.toString()),
+        id: url.split('/').at(-1),
+      } as any;
+    case /^\/programs\/[^/]+$/.test(url) && method === 'DELETE':
+      return { deleted: true } as any;
+    case /^\/programs\/[^/]+\/restore$/.test(url) && method === 'POST':
+      return { restored: true } as any;
+    case /^\/programs\/[^/]+\/templates(?:\?.*)?$/.test(url) && method === 'GET': {
+      const programId = url.split('/')[2]?.split('?')[0];
+      return {
+        data: seed.templates.filter(t => t.programId === programId),
+      } as any;
+    }
+    case /^\/programs\/[^/]+\/templates$/.test(url) && method === 'POST':
+      return {
+        ...opts?.body && JSON.parse(opts.body.toString()),
+        id: 'tmpl-new',
+        programId: url.split('/')[2],
+      } as any;
+    case /^\/programs\/[^/]+\/templates\/[^/]+$/.test(url) && method === 'PATCH':
+      return {
+        ...opts?.body && JSON.parse(opts.body.toString()),
+        id: url.split('/').at(-1),
+        programId: url.split('/')[2],
+      } as any;
+    case /^\/programs\/[^/]+\/templates\/[^/]+$/.test(url) && method === 'DELETE':
+      return { deleted: true } as any;
+    case /^\/programs\/[^/]+\/templates\/[^/]+\/restore$/.test(url) && method === 'POST':
+      return { restored: true } as any;
     case url.startsWith('/api/programs?'):
       return { data: p, meta: { total: p.length, page: 1 } } as any;
-    case /^\/api\/programs\/[^/]+\/publish$/.test(url) && opts?.method === 'POST':
+    case /^\/api\/programs\/[^/]+\/publish$/.test(url) && method === 'POST':
       return { published: true } as any;
-    case /^\/api\/programs\/[^/]+\/deprecate$/.test(url) && opts?.method === 'POST':
+    case /^\/api\/programs\/[^/]+\/deprecate$/.test(url) && method === 'POST':
       return { deprecated: true } as any;
-    case /^\/api\/programs\/[^/]+\/archive$/.test(url) && opts?.method === 'POST':
+    case /^\/api\/programs\/[^/]+\/archive$/.test(url) && method === 'POST':
       return { archived: true } as any;
-    case /^\/api\/programs\/[^/]+$/.test(url) && opts?.method === 'DELETE':
+    case /^\/api\/programs\/[^/]+$/.test(url) && method === 'DELETE':
       return { deleted: true } as any;
-    case /^\/api\/programs\/[^/]+\/restore$/.test(url) && opts?.method === 'POST':
+    case /^\/api\/programs\/[^/]+\/restore$/.test(url) && method === 'POST':
       return { restored: true } as any;
     case url.startsWith('/api/templates?'):
       return { data: seed.templates } as any;
-    case url === '/api/templates' && opts?.method === 'POST':
+    case url === '/api/templates' && method === 'POST':
       return { ...opts?.body && JSON.parse(opts.body.toString()), id: 'tmpl-new' } as any;
-    case /^\/api\/templates\/[^/]+$/.test(url) && opts?.method === 'PATCH':
+    case /^\/api\/templates\/[^/]+$/.test(url) && method === 'PATCH':
       return { ...opts?.body && JSON.parse(opts.body.toString()), id: url.split('/').at(-1) } as any;
-    case /^\/api\/programs\/[^/]+\/templates\/[^/]+$/.test(url) && opts?.method === 'DELETE':
+    case /^\/api\/programs\/[^/]+\/templates\/[^/]+$/.test(url) && method === 'DELETE':
       return { deleted: true } as any;
-    case /^\/api\/programs\/[^/]+\/templates\/[^/]+\/restore$/.test(url) && opts?.method === 'POST':
+    case /^\/api\/programs\/[^/]+\/templates\/[^/]+\/restore$/.test(url) && method === 'POST':
       return { restored: true } as any;
     case url.startsWith('/api/audit'):
       return seed.audit as any;
@@ -223,6 +307,7 @@ export const seed = {
   templates: [
     {
       id: 't1',
+      programId: 'p1',
       name: 'Engineer Onboarding',
       category: 'Engineering',
       updatedAt: '2024-05-15',
@@ -230,6 +315,7 @@ export const seed = {
     },
     {
       id: 't2',
+      programId: 'p2',
       name: 'Retail Associate Training',
       category: 'Operations',
       updatedAt: '2024-04-20',


### PR DESCRIPTION
## Summary
- update program and template API helpers to call the server's `/programs` routes and expose nested template helpers
- expand the mock fetch router and seed data to reflect program-scoped templates
- refresh ProgramsLanding so templates load per selected program and expose a selector for switching

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c94ef2bf1c832ca28e7bd605706dec