### PR TITLE
Update admin header links

### DIFF
--- a/src/admin/RoleManager.jsx
+++ b/src/admin/RoleManager.jsx
@@ -328,11 +328,11 @@ export default function RoleManager() {
             <a href="/admin/roles" className="btn btn-primary text-sm">
               Roles &amp; Programs
             </a>
-            <a href="/programs" className="btn btn-outline text-sm">
-              Programs
-            </a>
-            <a href="/programs?tab=templates" className="btn btn-outline text-sm">
-              Templates
+            <a
+              href="/admin/program-template-manager.html"
+              className="btn btn-outline text-sm"
+            >
+              Program Templates
             </a>
           </div>
         </header>


### PR DESCRIPTION
## Summary
- remove the Programs and Templates buttons from the role manager header
- add a Program Templates button that points to the admin program template manager

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c95d1295e8832cb524bdadc2417286