### PR TITLE
Simplify admin nav links

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -184,8 +184,6 @@
           <a href="/admin/user-manager" class="btn btn-outline text-sm">Users</a>
           <a href="/admin/role-manager.html" class="btn btn-outline text-sm">Roles &amp; Programs</a>
           <a href="/admin/program-template-manager.html" class="btn btn-primary text-sm">Program Templates</a>
-          <a href="/admin/program-template-manager.html" class="btn btn-outline text-sm">Programs</a>
-          <a href="/admin/program-template-manager.html?tab=templates" class="btn btn-outline text-sm">Templates</a>
         </div>
         <a href="/" class="text-sm text-anx-sky underline">← Back to Orientation</a>
       </div>

--- a/public/admin/role-manager.html
+++ b/public/admin/role-manager.html
@@ -19,9 +19,8 @@
       <div class="flex items-center gap-3">
         <div class="flex gap-2">
           <a href="/admin/user-manager" class="btn btn-outline text-sm">Users</a>
-          <a href="/admin/role-manager.html" class="btn btn-outline text-sm bg-anx-sky text-white">Roles &amp; Programs</a>
-          <a href="/admin/program-template-manager.html" class="btn btn-outline text-sm">Programs</a>
-          <a href="/admin/program-template-manager.html?tab=templates" class="btn btn-outline text-sm">Templates</a>
+          <a href="/admin/role-manager.html" class="btn btn-primary text-sm">Roles &amp; Programs</a>
+          <a href="/admin/program-template-manager.html" class="btn btn-outline text-sm">Program Templates</a>
         </div>
         <a href="/" class="text-sm text-anx-sky underline">← Back to Orientation</a>
       </div>

--- a/public/admin/user-manager.html
+++ b/public/admin/user-manager.html
@@ -18,10 +18,9 @@
       </div>
       <div class="flex items-center gap-3">
         <div class="flex gap-2">
-          <a href="/admin/user-manager" class="btn btn-outline text-sm bg-anx-sky text-white">Users</a>
+          <a href="/admin/user-manager" class="btn btn-primary text-sm">Users</a>
           <a href="/admin/role-manager.html" class="btn btn-outline text-sm">Roles &amp; Programs</a>
-          <a href="/admin/program-template-manager.html" class="btn btn-outline text-sm">Programs</a>
-          <a href="/admin/program-template-manager.html?tab=templates" class="btn btn-outline text-sm">Templates</a>
+          <a href="/admin/program-template-manager.html" class="btn btn-outline text-sm">Program Templates</a>
         </div>
         <a href="/" class="text-sm text-anx-sky underline">← Back to Orientation</a>
       </div>


### PR DESCRIPTION
## Summary
- update admin navigation to show only Users, Roles & Programs, and Program Templates
- apply consistent button styles so the current page uses the primary variant while others remain outline

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c95e109010832c8c630effdff918a2