### PR TITLE
Simplify admin nav links

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -184,8 +184,6 @@
           <a href="/admin/user-manager" class="btn btn-outline text-sm">Users</a>
           <a href="/admin/role-manager.html" class="btn btn-outline text-sm">Roles &amp; Programs</a>
           <a href="/admin/program-template-manager.html" class="btn btn-primary text-sm">Program Templates</a>
-          <a href="/admin/program-template-manager.html" class="btn btn-outline text-sm">Programs</a>
-          <a href="/admin/program-template-manager.html?tab=templates" class="btn btn-outline text-sm">Templates</a>
         </div>
         <a href="/" class="text-sm text-anx-sky underline">← Back to Orientation</a>
       </div>

--- a/public/admin/role-manager.html
+++ b/public/admin/role-manager.html
@@ -10,18 +10,17 @@
   </script>
 </head>
 <body class="bg-slate-50 text-slate-900">
-  <div class="max-w-6xl mx-auto p-4 space-y-4">
-    <header class="flex items-center justify-between gap-4">
+  <div class="max-w-6xl mx-auto p-4 space-y-6">
+    <header class="flex items-center justify-between gap-4 flex-wrap">
       <div>
         <h1 class="text-2xl font-bold">Role &amp; Program Manager</h1>
         <p class="text-sm text-slate-500">Manage permissions and preload programs for your team.</p>
       </div>
-      <div class="flex items-center gap-3">
-        <div class="flex gap-2">
+      <div class="flex items-center gap-3 flex-wrap justify-end">
+        <div class="flex flex-wrap gap-2">
           <a href="/admin/user-manager" class="btn btn-outline text-sm">Users</a>
-          <a href="/admin/role-manager.html" class="btn btn-outline text-sm bg-anx-sky text-white">Roles &amp; Programs</a>
-          <a href="/admin/program-template-manager.html" class="btn btn-outline text-sm">Programs</a>
-          <a href="/admin/program-template-manager.html?tab=templates" class="btn btn-outline text-sm">Templates</a>
+          <a href="/admin/role-manager.html" class="btn btn-primary text-sm">Roles &amp; Programs</a>
+          <a href="/admin/program-template-manager.html" class="btn btn-outline text-sm">Program Templates</a>
         </div>
         <a href="/" class="text-sm text-anx-sky underline">← Back to Orientation</a>
       </div>

--- a/public/admin/user-manager.html
+++ b/public/admin/user-manager.html
@@ -10,18 +10,17 @@
   </script>
 </head>
 <body class="bg-slate-50 text-slate-900">
-  <div class="max-w-6xl mx-auto p-4 space-y-4">
-    <header class="flex items-center justify-between gap-4">
+  <div class="max-w-6xl mx-auto p-4 space-y-6">
+    <header class="flex items-center justify-between gap-4 flex-wrap">
       <div>
         <h1 class="text-2xl font-bold">User Manager</h1>
         <p class="text-sm text-slate-500">Invite teammates, update their profiles, and control access.</p>
       </div>
-      <div class="flex items-center gap-3">
-        <div class="flex gap-2">
-          <a href="/admin/user-manager" class="btn btn-outline text-sm bg-anx-sky text-white">Users</a>
+      <div class="flex items-center gap-3 flex-wrap justify-end">
+        <div class="flex flex-wrap gap-2">
+          <a href="/admin/user-manager" class="btn btn-primary text-sm">Users</a>
           <a href="/admin/role-manager.html" class="btn btn-outline text-sm">Roles &amp; Programs</a>
-          <a href="/admin/program-template-manager.html" class="btn btn-outline text-sm">Programs</a>
-          <a href="/admin/program-template-manager.html?tab=templates" class="btn btn-outline text-sm">Templates</a>
+          <a href="/admin/program-template-manager.html" class="btn btn-outline text-sm">Program Templates</a>
         </div>
         <a href="/" class="text-sm text-anx-sky underline">← Back to Orientation</a>
       </div>


### PR DESCRIPTION
## Summary
- update admin navigation to show only Users, Roles & Programs, and Program Templates
- apply consistent button styles so the current page uses the primary variant while others remain outline
- match navigation layout across User and Role managers to Program Template Manager

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c95e109010832c8c630effdff918a2