### PR TITLE
Add program template status handling and scoped APIs

### DIFF
--- a/migrations/008_add_status_to_program_task_templates.sql
+++ b/migrations/008_add_status_to_program_task_templates.sql
@@ -1,0 +1,8 @@
+-- 008_add_status_to_program_task_templates.sql
+-- Add status tracking for program task templates.
+
+alter table public.program_task_templates
+  add column if not exists status text default 'draft';
+
+update public.program_task_templates
+  set status = coalesce(status, 'draft');


### PR DESCRIPTION
## Summary
- add a status column and validation to the program template endpoints so PATCH/POST work on program-scoped URLs
- update the mock API to use program-specific template routes with normalized statuses and drop global template fetch handling
- add a migration and tests covering the new status column and invalid status validation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c989d03280832c9f118728cd66cf6d