### PR TITLE
Prefer program label for template name display

### DIFF
--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -82,9 +82,9 @@ function getTemplateId(template) {
 
 function getTemplateName(template) {
   const value = [
+    template?.label,
     template?.name,
     template?.title,
-    template?.label,
     template?.template?.name,
     template?.template?.title,
     template?.template?.label,


### PR DESCRIPTION
## Summary
- prefer a program-template association's label when determining the display name
- continue falling back to other template name/title fields when a label is not provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9d11e0b04832c86a68c8a0a82f9f3