### PR TITLE
Add Tagify assets and new attach controls to program template panel

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -5,6 +5,8 @@
   <title>ANX • Program &amp; Template Manager</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@yaireo/tagify/dist/tagify.css">
+  <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify/dist/tagify.min.js"></script>
   <script>
     tailwind.config = { theme: { extend: { colors: { anx: { sky: '#0ea5e9' }}}}};
   </script>
@@ -402,17 +404,19 @@
         </div>
 
         <aside id="programTemplatePanel" class="panel-section hidden p-4 space-y-4" aria-live="polite">
-          <div class="flex items-start justify-between gap-3 flex-wrap">
-            <div class="space-y-1">
-              <h3 id="programTemplatePanelTitle" class="text-lg font-semibold">Program templates</h3>
-              <p id="programTemplatePanelDescription" class="text-sm text-slate-500">Select a program to manage template assignments.</p>
-            </div>
-            <button id="btnPanelAddTemplate" class="btn btn-primary text-sm">Add Template</button>
+          <div class="space-y-1">
+            <h3 id="programTemplatePanelTitle" class="text-lg font-semibold">Program templates</h3>
+            <p id="programTemplatePanelDescription" class="text-sm text-slate-500">Select a program to manage template assignments.</p>
           </div>
           <p id="programTemplatePanelMessage" class="text-xs text-slate-500 hidden"></p>
           <div id="programTemplatePanelEmpty" class="text-sm text-slate-500 border border-dashed border-slate-300 rounded-xl p-4 text-center hidden">
             No templates assigned to this program yet.
           </div>
+          <div id="tagAttachRow" class="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+            <input id="programTemplateAttachInput" type="text" class="input" placeholder="Search templates to attach…">
+            <button id="btnPanelAttachTemplate" class="btn btn-primary text-sm">Attach Template</button>
+          </div>
+          <small class="block text-xs text-slate-500">Search existing templates to attach to this program.</small>
           <ul id="programTemplateList" class="space-y-4" aria-live="polite"></ul>
           <datalist id="templateVisibilityOptions">
             <option value="inherit"></option>


### PR DESCRIPTION
## Summary
- load Tagify's vanilla CSS and JS assets alongside Tailwind for the program template manager
- replace the panel header action area with a Tagify-ready attach row and helper text before the template list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9f1e05d84832cb0a03f10a48105d2