### PR TITLE
Enforce program weeks validation

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -67,6 +67,14 @@
       box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
     }
 
+    .input:invalid,
+    .input[aria-invalid="true"],
+    .textarea:invalid,
+    .textarea[aria-invalid="true"] {
+      border-color: #dc2626;
+      box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.15);
+    }
+
     .textarea {
       width: 100%;
       border-radius: 0.75rem;
@@ -444,8 +452,8 @@
           </div>
           <div class="grid gap-3 md:grid-cols-2">
             <label class="space-y-1">
-              <span class="label-text">Total weeks</span>
-              <input id="programFormWeeks" name="total_weeks" type="number" min="1" class="input" placeholder="e.g. 12">
+              <span class="label-text">Total weeks <span class="text-red-600" aria-hidden="true">*</span><span class="sr-only">Required</span></span>
+              <input id="programFormWeeks" name="total_weeks" type="number" min="1" class="input" placeholder="e.g. 12" required>
             </label>
             <div class="space-y-1">
               <span class="label-text">Lifecycle</span>

--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -358,6 +358,7 @@ let reorderInFlightPromise = null;
 let metadataSaveTimeout = null;
 let reorderSaveTimeout = null;
 const METADATA_SAVE_DELAY_MS = 600;
+let programWeeksInvalidInputHandler = null;
 const REORDER_SAVE_DELAY_MS = 400;
 const ATTACH_SAVE_DELAY_MS = 600;
 const pendingMetadataState = {
@@ -689,9 +690,42 @@ function setProgramFormMessage(text, isError = false) {
   setModalMessage(programFormMessage, text, isError);
 }
 
+function getProgramSubmitDefaultLabel() {
+  return programModalMode === 'edit' ? 'Save Changes' : 'Create Program';
+}
+
+function clearProgramWeeksValidationState() {
+  if (programFormWeeksInput) {
+    programFormWeeksInput.setCustomValidity('');
+    programFormWeeksInput.removeAttribute('aria-invalid');
+    if (programWeeksInvalidInputHandler) {
+      programFormWeeksInput.removeEventListener('input', programWeeksInvalidInputHandler);
+      programWeeksInvalidInputHandler = null;
+    }
+  }
+}
+
+function validateProgramWeeks(value) {
+  const rawValue = value ?? '';
+  const normalized = typeof rawValue === 'string' ? rawValue.trim() : String(rawValue).trim();
+  if (!normalized) {
+    return { valid: false, message: 'Total weeks is required.' };
+  }
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    return { valid: false, message: 'Total weeks must be a positive whole number.' };
+  }
+  return { valid: true, value: parsed };
+}
+
 function resetProgramForm() {
   if (programForm) {
     programForm.reset();
+  }
+  clearProgramWeeksValidationState();
+  if (programFormSubmit) {
+    programFormSubmit.disabled = false;
+    programFormSubmit.textContent = getProgramSubmitDefaultLabel();
   }
   setProgramFormMessage('');
 }
@@ -1641,6 +1675,10 @@ function openProgramModal(mode = 'create', programId = null) {
   if (programForm) {
     programForm.reset();
   }
+  clearProgramWeeksValidationState();
+  if (programFormSubmit) {
+    programFormSubmit.disabled = false;
+  }
   const isDangerVisible = isEdit && CAN_MANAGE_PROGRAMS;
   if (programModalArchiveTrigger) {
     programModalArchiveTrigger.classList.toggle('hidden', !isDangerVisible);
@@ -1789,38 +1827,62 @@ async function submitProgramForm(event) {
     return;
   }
   const initialSubmitLabel = programFormSubmit ? programFormSubmit.textContent : '';
+  const defaultSubmitLabel = initialSubmitLabel || getProgramSubmitDefaultLabel();
   if (programFormSubmit) {
     programFormSubmit.disabled = true;
+    programFormSubmit.textContent = defaultSubmitLabel;
   }
   const title = (programFormTitleInput?.value || '').trim();
   if (!title) {
     setProgramFormMessage('Program title is required.', true);
     if (programFormSubmit) {
       programFormSubmit.disabled = false;
-      programFormSubmit.textContent = initialSubmitLabel;
+      programFormSubmit.textContent = defaultSubmitLabel;
     }
     programFormTitleInput?.focus();
     return;
   }
-  const weeksValue = programFormWeeksInput?.value || '';
-  let totalWeeks = null;
-  if (weeksValue !== '') {
-    const parsed = Number(weeksValue);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-      setProgramFormMessage('Total weeks must be a positive number.', true);
-      if (programFormSubmit) {
-        programFormSubmit.disabled = false;
-        programFormSubmit.textContent = initialSubmitLabel;
+  const weeksValue = programFormWeeksInput?.value ?? '';
+  const weeksValidation = validateProgramWeeks(weeksValue);
+  if (!weeksValidation.valid) {
+    const message = weeksValidation.message;
+    setProgramFormMessage(message, true);
+    if (programFormWeeksInput) {
+      programFormWeeksInput.setCustomValidity(message);
+      programFormWeeksInput.setAttribute('aria-invalid', 'true');
+      if (!programWeeksInvalidInputHandler) {
+        programWeeksInvalidInputHandler = () => {
+          if (!programFormWeeksInput) return;
+          const nextValidation = validateProgramWeeks(programFormWeeksInput.value);
+          if (nextValidation.valid) {
+            clearProgramWeeksValidationState();
+            setProgramFormMessage('');
+            if (programFormSubmit) {
+              programFormSubmit.disabled = false;
+              programFormSubmit.textContent = defaultSubmitLabel;
+            }
+          } else {
+            programFormWeeksInput.setCustomValidity(nextValidation.message);
+            programFormWeeksInput.setAttribute('aria-invalid', 'true');
+            setProgramFormMessage(nextValidation.message, true);
+          }
+        };
+        programFormWeeksInput.addEventListener('input', programWeeksInvalidInputHandler);
       }
-      programFormWeeksInput?.focus();
-      return;
+      programFormWeeksInput.reportValidity?.();
+      programFormWeeksInput.focus();
+    } else if (programFormSubmit) {
+      programFormSubmit.disabled = false;
+      programFormSubmit.textContent = defaultSubmitLabel;
     }
-    totalWeeks = parsed;
+    return;
   }
+  const totalWeeks = weeksValidation.value;
+  clearProgramWeeksValidationState();
   const descriptionValue = (programFormDescriptionInput?.value || '').trim();
   const payload = {
     title,
-    total_weeks: totalWeeks === null ? null : totalWeeks,
+    total_weeks: totalWeeks,
     description: descriptionValue ? descriptionValue : null,
   };
   const encodedId = targetId ? encodeURIComponent(targetId) : null;


### PR DESCRIPTION
## Summary
- mark the program form's total weeks input as required and add a visible required indicator
- add shared invalid-state styling so both program and template forms highlight fields that fail validation
- tighten submitProgramForm logic to require a positive integer week count, manage custom validity feedback, and send a sanitized payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca0218dd88832c9d0de031b6e73501