### PR TITLE
Fix attach tag control IDs

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -430,8 +430,8 @@
             No templates assigned to this program yet.
           </div>
           <div id="tagAttachRow" class="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
-            <input id="programTemplateAttachInput" type="text" class="input" placeholder="Search templates to attach…">
-            <button id="btnPanelAttachTemplate" class="btn btn-primary text-sm">Attach Template</button>
+            <input id="templateAttachTagify" type="text" class="input" placeholder="Search templates to attach…">
+            <button id="btnAttachTags" class="btn btn-primary text-sm">Attach Template</button>
           </div>
           <small class="block text-xs text-slate-500">Search existing templates to attach to this program.</small>
           <ul id="programTemplateList" class="space-y-4" aria-live="polite"></ul>


### PR DESCRIPTION
## Summary
- align the program template attach input and button IDs with the JavaScript controller so Tagify can bind correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca15936178832c8b59528d3f50cfbf