### PR TITLE
Add program tag support and shared tag suggestions

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -475,6 +475,10 @@
             <label for="programFormDescription" class="label-text mb-1">Description</label>
             <textarea id="programFormDescription" name="description" class="textarea" placeholder="Add an overview for collaborators..."></textarea>
           </div>
+          <div>
+            <label for="programFormTags" class="label-text mb-1">Tags</label>
+            <input id="programFormTags" name="tags" class="input" placeholder="Add tags…">
+          </div>
           <p id="programFormMessage" class="text-sm text-slate-500 hidden"></p>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
## Summary
- add a tags field to the Program modal and manage it with Tagify alongside existing inputs
- initialize/destroy the program Tagify instance when the modal opens or closes, seeding and resetting tag values
- refresh a shared tag whitelist from program and template data so both modals share suggestions and include tags in program submissions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca1e2ab850832c8affe23d77de64d0