### PR TITLE
Fix program template attachment controls

### DIFF
--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -326,8 +326,8 @@ const programTemplatePanelDescription = document.getElementById('programTemplate
 const programTemplatePanelMessage = document.getElementById('programTemplatePanelMessage');
 const programTemplatePanelEmpty = document.getElementById('programTemplatePanelEmpty');
 const programTemplateList = document.getElementById('programTemplateList');
-const templateAttachInput = document.getElementById('templateAttachTagify');
-const btnAttachTags = document.getElementById('btnAttachTags');
+const templateAttachInput = document.getElementById('programTemplateAttachInput');
+const btnAttachTags = document.getElementById('btnPanelAttachTemplate');
 const templateVisibilityOptions = document.getElementById('templateVisibilityOptions');
 
 if (!programTableBody || !templateTableBody || !programActionsContainer || !templateActionsContainer) {


### PR DESCRIPTION
## Summary
- point the program template Tagify input selector at the rendered field
- hook the attach button handler up to the actual control so Tagify selections can flush attachments

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cb016f4e60832cb906f6781441c517