### PR TITLE
Update template API endpoints

### DIFF
--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -1,4 +1,5 @@
 const API = window.location.origin;
+const TEMPLATE_API = `${API}/api/templates`;
 
 async function fetchJson(url, options = {}) {
   const res = await fetch(url, { credentials: 'include', ...options });
@@ -1937,8 +1938,8 @@ async function submitTemplateForm(event) {
   };
   const encodedTemplateId = targetId ? encodeURIComponent(targetId) : null;
   const url = isEdit && encodedTemplateId
-    ? `${API}/templates/${encodedTemplateId}`
-    : `${API}/templates`;
+    ? `${TEMPLATE_API}/${encodedTemplateId}`
+    : TEMPLATE_API;
   const method = isEdit ? 'PATCH' : 'POST';
   if (templateFormSubmit) {
     templateFormSubmit.textContent = isEdit ? 'Saving…' : 'Creating…';
@@ -2766,7 +2767,7 @@ async function loadTemplates(options = {}) {
     }
     params.set('include_deleted', 'true');
     const search = params.toString();
-    const url = search ? `${API}/templates?${search}` : `${API}/templates`;
+    const url = search ? `${TEMPLATE_API}?${search}` : TEMPLATE_API;
     const data = await fetchJson(url);
     let fetched = [];
     if (Array.isArray(data?.data)) {
@@ -3110,7 +3111,7 @@ async function handleTemplateAction(action) {
   let failure = 0;
   for (const id of ids) {
     try {
-      const res = await fetch(`${API}/templates/${encodeURIComponent(id)}`, {
+      const res = await fetch(`${TEMPLATE_API}/${encodeURIComponent(id)}`, {
         method: 'PATCH',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- update the admin template manager to target the /api/templates endpoint for global template operations
- reuse a shared TEMPLATE_API constant in create/edit, list, and bulk action requests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb07a2c770832cbd34671a5de5ee69