### PR TITLE
Add program template m2m links and seed data

### DIFF
--- a/migrations/008_templates_m2m.sql
+++ b/migrations/008_templates_m2m.sql
@@ -1,0 +1,25 @@
+-- 008_templates_m2m.sql
+-- Introduce a join table between programs and task templates.
+
+begin;
+
+create table if not exists public.program_template_links (
+  template_id uuid not null references public.program_task_templates(template_id) on delete cascade,
+  program_id  text not null references public.programs(program_id) on delete cascade,
+  created_at  timestamptz not null default now(),
+  primary key (template_id, program_id)
+);
+
+create index if not exists idx_program_template_links_program on public.program_template_links(program_id);
+create index if not exists idx_program_template_links_template on public.program_template_links(template_id);
+
+insert into public.program_template_links (template_id, program_id, created_at)
+select template_id, program_id, now()
+from public.program_task_templates
+where program_id is not null
+on conflict do nothing;
+
+alter table public.program_task_templates
+drop column if exists program_id;
+
+commit;

--- a/migrations/008_templates_m2m_down.sql
+++ b/migrations/008_templates_m2m_down.sql
@@ -1,0 +1,26 @@
+-- 008_templates_m2m_down.sql
+-- Revert program/template m2m relationship.
+
+begin;
+
+alter table public.program_task_templates
+  add column if not exists program_id text references public.programs(program_id);
+
+update public.program_task_templates t
+set program_id = sub.program_id
+from (
+  select template_id, program_id
+  from (
+    select template_id,
+           program_id,
+           created_at,
+           row_number() over (partition by template_id order by created_at, program_id) as rn
+    from public.program_template_links
+  ) ranked
+  where rn = 1
+) sub
+where t.template_id = sub.template_id;
+
+drop table if exists public.program_template_links;
+
+commit;

--- a/migrations/008b_seed_templates.sql
+++ b/migrations/008b_seed_templates.sql
@@ -1,0 +1,33 @@
+-- 008b_seed_templates.sql
+-- Seed sample templates and attach them to demo programs.
+
+begin;
+
+-- Ensure sample programs exist for attaching templates.
+insert into public.programs (program_id, title, total_weeks, description, created_at)
+values
+  ('sample_onboarding', 'Sample Onboarding Program', 4, 'Baseline orientation flow used for demo accounts.', now()),
+  ('sample_remote_onboarding', 'Sample Remote Onboarding', 3, 'Remote-friendly onboarding milestones.', now())
+on conflict (program_id) do nothing;
+
+-- Seed template records.
+insert into public.program_task_templates (template_id, week_number, label, notes, sort_order, status)
+values
+  ('11111111-2222-4333-8444-555555555551', 1, 'Welcome & Introductions', 'Greet the new hire and review the agenda.', 1, 'published'),
+  ('11111111-2222-4333-8444-555555555552', 1, 'IT & Accounts Setup', 'Provision laptop, email, and internal tools.', 2, 'published'),
+  ('11111111-2222-4333-8444-555555555553', 2, 'Meet Your Mentor', 'Schedule a mentor pairing conversation.', 3, 'published'),
+  ('11111111-2222-4333-8444-555555555554', 1, 'Remote Work Best Practices', 'Share communication norms and meeting cadence.', 1, 'published'),
+  ('11111111-2222-4333-8444-555555555555', 2, 'Virtual Team Lunch', 'Host a remote-friendly get-to-know-you lunch.', 2, 'published')
+on conflict (template_id) do nothing;
+
+-- Attach templates to their respective programs.
+insert into public.program_template_links (template_id, program_id)
+values
+  ('11111111-2222-4333-8444-555555555551', 'sample_onboarding'),
+  ('11111111-2222-4333-8444-555555555552', 'sample_onboarding'),
+  ('11111111-2222-4333-8444-555555555553', 'sample_onboarding'),
+  ('11111111-2222-4333-8444-555555555554', 'sample_remote_onboarding'),
+  ('11111111-2222-4333-8444-555555555555', 'sample_remote_onboarding')
+on conflict do nothing;
+
+commit;


### PR DESCRIPTION
## Summary
- introduce a program_template_links join table, backfill existing template assignments, and provide a down migration
- update API routes to use the join table when managing templates and instantiating tasks, and refresh tests for the new schema
- seed demo programs and templates using the new relationship

## Testing
- npm test -- programRoutes

------
https://chatgpt.com/codex/tasks/task_e_68cb1a3aa240832c8d8f2b3a561a73bf