### PR TITLE
Align template link type with bigint template IDs

### DIFF
--- a/migrations/008_templates_m2m.sql
+++ b/migrations/008_templates_m2m.sql
@@ -3,13 +3,55 @@
 
 begin;
 
-create table if not exists public.program_template_links (
-  template_id public.program_task_templates.template_id%TYPE not null
-    references public.program_task_templates(template_id) on delete cascade,
-  program_id  text not null references public.programs(program_id) on delete cascade,
-  created_at  timestamptz not null default now(),
-  primary key (template_id, program_id)
-);
+do $$
+begin
+  if not exists (
+    select 1
+    from information_schema.tables
+    where table_schema = 'public'
+      and table_name = 'program_template_links'
+  ) then
+    create table public.program_template_links (
+      template_id public.program_task_templates.template_id%TYPE not null,
+      program_id  text not null,
+      created_at  timestamptz not null default now(),
+      primary key (template_id, program_id)
+    );
+  end if;
+end
+$$;
+
+drop index if exists idx_program_template_links_program;
+drop index if exists idx_program_template_links_template;
+
+alter table public.program_template_links
+  drop constraint if exists program_template_links_template_id_fkey,
+  drop constraint if exists program_template_links_program_id_fkey,
+  drop constraint if exists program_template_links_pkey;
+
+alter table public.program_template_links
+  alter column template_id type public.program_task_templates.template_id%TYPE
+    using trim(template_id::text)::public.program_task_templates.template_id%TYPE,
+  alter column template_id set not null,
+  alter column program_id type text,
+  alter column program_id set not null,
+  alter column created_at type timestamptz using created_at::timestamptz,
+  alter column created_at set default now();
+
+alter table public.program_template_links
+  add constraint program_template_links_pkey primary key (template_id, program_id);
+
+alter table public.program_template_links
+  add constraint program_template_links_template_id_fkey
+    foreign key (template_id)
+    references public.program_task_templates(template_id)
+    on delete cascade;
+
+alter table public.program_template_links
+  add constraint program_template_links_program_id_fkey
+    foreign key (program_id)
+    references public.programs(program_id)
+    on delete cascade;
 
 create index if not exists idx_program_template_links_program on public.program_template_links(program_id);
 create index if not exists idx_program_template_links_template on public.program_template_links(template_id);

--- a/migrations/008_templates_m2m_down.sql
+++ b/migrations/008_templates_m2m_down.sql
@@ -21,6 +21,14 @@ from (
 ) sub
 where t.template_id = sub.template_id;
 
+drop index if exists idx_program_template_links_program;
+drop index if exists idx_program_template_links_template;
+
+alter table if exists public.program_template_links
+  drop constraint if exists program_template_links_template_id_fkey,
+  drop constraint if exists program_template_links_program_id_fkey,
+  drop constraint if exists program_template_links_pkey;
+
 drop table if exists public.program_template_links;
 
 commit;

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -1232,9 +1232,9 @@ create table if not exists public.program_task_templates (
 );
 
 create table if not exists public.program_template_links (
-  template_id bigint references public.program_task_templates(template_id) on delete cascade,
-  program_id  text references public.programs(program_id) on delete cascade,
-  created_at  timestamptz default now(),
+  template_id bigint not null references public.program_task_templates(template_id) on delete cascade,
+  program_id  text not null references public.programs(program_id) on delete cascade,
+  created_at  timestamptz not null default now(),
   primary key (template_id, program_id)
 );
 create index if not exists idx_program_template_links_program on public.program_template_links(program_id);


### PR DESCRIPTION
## Summary
- ensure the program_template_links.template_id column inherits the program_task_templates identifier type while rebuilding keys/indexes in both migrations
- update orientation server bootstrap DDL and the program routes test fixtures to expect bigint template identifiers

## Testing
- npm test -- programRoutes

------
https://chatgpt.com/codex/tasks/task_e_68cb3fd6c9c8832cbef2e0af0363bbf1