### PR TITLE
Add template API with join table support

### DIFF
--- a/__tests__/templateApi.test.js
+++ b/__tests__/templateApi.test.js
@@ -1,0 +1,374 @@
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+const crypto = require('crypto');
+const { newDb } = require('pg-mem');
+
+const nextTemplateId = (() => {
+  let value = 2000;
+  return () => ++value;
+})();
+
+const db = newDb();
+const { Pool: MockPool } = db.adapters.createPg();
+db.public.registerFunction({
+  name: 'gen_random_uuid',
+  returns: 'uuid',
+  implementation: () => crypto.randomUUID(),
+});
+db.public.registerFunction({
+  name: 'to_timestamp',
+  args: ['text'],
+  returns: 'timestamptz',
+  implementation: value => new Date(Number(value) * 1000),
+});
+
+jest.mock('pg', () => ({ Pool: MockPool }));
+
+const { app, pool } = require('../orientation_server.js');
+
+const DEFAULT_PASSWORD = 'passpass';
+
+describe('template api', () => {
+  beforeAll(async () => {
+    await pool.query(`
+      create table public.users (
+        id uuid primary key,
+        username text unique,
+        email text,
+        full_name text,
+        password_hash text,
+        provider text,
+        last_login_at timestamptz
+      );
+      create table public.session (
+        sid text primary key,
+        sess text not null,
+        expire timestamptz not null
+      );
+      create table public.roles (
+        role_id serial primary key,
+        role_key text unique,
+        description text
+      );
+      create table public.programs (
+        program_id text primary key,
+        title text not null,
+        total_weeks int,
+        description text,
+        created_by uuid,
+        created_at timestamptz default now(),
+        deleted_at timestamp
+      );
+      create table public.program_task_templates (
+        template_id bigserial primary key,
+        week_number int,
+        label text not null,
+        notes text,
+        sort_order int,
+        status text default 'draft',
+        deleted_at timestamp
+      );
+      create table public.program_template_links (
+        template_id bigint not null references public.program_task_templates(template_id) on delete cascade,
+        program_id text not null references public.programs(program_id) on delete cascade,
+        created_at timestamptz not null default now(),
+        primary key (template_id, program_id)
+      );
+      create table public.user_roles (
+        user_id uuid,
+        role_id int references public.roles(role_id)
+      );
+      create table public.role_permissions (
+        role_id int references public.roles(role_id),
+        perm_key text
+      );
+      create table public.program_memberships (
+        user_id uuid,
+        program_id text,
+        role text
+      );
+      insert into public.roles(role_key) values ('admin'), ('manager'), ('viewer'), ('trainee'), ('auditor');
+    `);
+  });
+
+  afterEach(async () => {
+    await pool.query('delete from public.program_template_links');
+    await pool.query('delete from public.program_task_templates');
+    await pool.query('delete from public.program_memberships');
+    await pool.query('delete from public.programs');
+    await pool.query('delete from public.user_roles');
+    await pool.query('delete from public.role_permissions');
+    await pool.query('delete from public.session');
+    await pool.query('delete from public.users');
+  });
+
+  const createUserWithRole = async (username, roleKey) => {
+    const userId = crypto.randomUUID();
+    const passwordHash = await bcrypt.hash(DEFAULT_PASSWORD, 1);
+    await pool.query(
+      'insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)',
+      [userId, username, passwordHash, 'local']
+    );
+    if (roleKey) {
+      await pool.query(
+        'insert into public.user_roles(user_id, role_id) select $1, role_id from public.roles where role_key = $2',
+        [userId, roleKey]
+      );
+    }
+    return userId;
+  };
+
+  const loginAgent = async username => {
+    const agent = request.agent(app);
+    await agent.post('/auth/local/login').send({ username, password: DEFAULT_PASSWORD }).expect(200);
+    return agent;
+  };
+
+  const grantPermission = async permKey => {
+    await pool.query(
+      'insert into public.role_permissions(role_id, perm_key) select role_id, $1 from public.roles where role_key = $2',
+      [permKey, 'manager']
+    );
+  };
+
+  test('GET /api/templates supports pagination and filtering', async () => {
+    const adminUsername = 'admin-templates';
+    await createUserWithRole(adminUsername, 'admin');
+
+    for (let i = 0; i < 6; i += 1) {
+      const templateId = nextTemplateId();
+      const status = i % 2 === 0 ? 'draft' : 'published';
+      await pool.query(
+        'insert into public.program_task_templates(template_id, week_number, label, notes, sort_order, status) values ($1,$2,$3,$4,$5,$6)',
+        [templateId, i + 1, `Template ${i}`, `Notes ${i}`, i, status]
+      );
+    }
+    const deletedId = nextTemplateId();
+    await pool.query(
+      'insert into public.program_task_templates(template_id, week_number, label, status, deleted_at) values ($1,$2,$3,$4, now())',
+      [deletedId, 7, 'Deleted Template', 'draft']
+    );
+
+    const agent = await loginAgent(adminUsername);
+
+    const res = await agent
+      .get('/api/templates')
+      .query({ limit: 2, offset: 1, status: 'draft', search: 'Template' })
+      .expect(200);
+
+    expect(res.body.meta).toMatchObject({ limit: 2, offset: 1 });
+    expect(res.body.meta.total).toBeGreaterThanOrEqual(2);
+    expect(res.body.data.length).toBeLessThanOrEqual(2);
+    res.body.data.forEach(item => {
+      expect(item.status).toBe('draft');
+      expect(item.label).toMatch(/Template/);
+    });
+
+    const includeDeleted = await agent
+      .get('/api/templates')
+      .query({ include_deleted: 'true', status: 'draft' })
+      .expect(200);
+
+    const hasDeleted = includeDeleted.body.data.some(row => row.label === 'Deleted Template');
+    expect(hasDeleted).toBe(true);
+
+    await agent.get('/api/templates').query({ status: 'invalid' }).expect(400);
+  });
+
+  test('POST /api/templates enforces validation rules', async () => {
+    const adminUsername = 'admin-create';
+    await createUserWithRole(adminUsername, 'admin');
+    const agent = await loginAgent(adminUsername);
+
+    await agent.post('/api/templates').send({ label: '' }).expect(400);
+    await agent.post('/api/templates').send({ label: 'Week', week_number: 'abc' }).expect(400);
+    await agent.post('/api/templates').send({ label: 'Week', sort_order: 'abc' }).expect(400);
+    await agent.post('/api/templates').send({ label: 'Week', status: 'archived' }).expect(400);
+
+    const res = await agent
+      .post('/api/templates')
+      .send({ label: 'New Template', week_number: 1, notes: 'Intro', sort_order: 3, status: 'published' })
+      .expect(201);
+
+    expect(res.body.label).toBe('New Template');
+    expect(res.body.status).toBe('published');
+
+    const { rows } = await pool.query('select label, status from public.program_task_templates where label = $1', [
+      'New Template',
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe('published');
+  });
+
+  test('PATCH /api/templates updates editable fields', async () => {
+    const adminUsername = 'admin-update';
+    await createUserWithRole(adminUsername, 'admin');
+    const agent = await loginAgent(adminUsername);
+
+    const templateId = nextTemplateId();
+    await pool.query(
+      'insert into public.program_task_templates(template_id, week_number, label, notes, sort_order, status) values ($1,$2,$3,$4,$5,$6)',
+      [templateId, 1, 'Initial', 'Start', 1, 'draft']
+    );
+
+    const res = await agent
+      .patch(`/api/templates/${templateId}`)
+      .send({ label: 'Updated', week_number: 2, sort_order: 5, notes: 'Updated notes', status: 'published' })
+      .expect(200);
+
+    expect(res.body.label).toBe('Updated');
+    expect(res.body.week_number).toBe(2);
+    expect(res.body.sort_order).toBe(5);
+    expect(res.body.status).toBe('published');
+
+    await agent
+      .patch(`/api/templates/${templateId}`)
+      .send({ status: 'archived' })
+      .expect(400);
+  });
+
+  test('DELETE and restore templates toggle soft delete flag', async () => {
+    const adminUsername = 'admin-delete';
+    await createUserWithRole(adminUsername, 'admin');
+    const agent = await loginAgent(adminUsername);
+
+    const templateId = nextTemplateId();
+    await pool.query(
+      'insert into public.program_task_templates(template_id, week_number, label) values ($1,$2,$3)',
+      [templateId, 1, 'Soft Delete']
+    );
+
+    await agent.delete(`/api/templates/${templateId}`).expect(200, { deleted: true });
+
+    let { rows } = await pool.query('select deleted_at from public.program_task_templates where template_id=$1', [templateId]);
+    expect(rows[0].deleted_at).not.toBeNull();
+
+    await agent.post(`/api/templates/${templateId}/restore`).expect(200, { restored: true });
+
+    ({ rows } = await pool.query('select deleted_at from public.program_task_templates where template_id=$1', [templateId]));
+    expect(rows[0].deleted_at).toBeNull();
+  });
+
+  test('listing template program associations returns attached programs', async () => {
+    const adminUsername = 'admin-list-programs';
+    await createUserWithRole(adminUsername, 'admin');
+    const agent = await loginAgent(adminUsername);
+
+    const programId = 'program-list';
+    await pool.query('insert into public.programs(program_id, title) values ($1,$2)', [programId, 'Program']);
+
+    const templateOne = nextTemplateId();
+    const templateTwo = nextTemplateId();
+    await pool.query('insert into public.program_task_templates(template_id, label) values ($1,$2)', [
+      templateOne,
+      'Template One',
+    ]);
+    await pool.query('insert into public.program_task_templates(template_id, label, status) values ($1,$2,$3)', [
+      templateTwo,
+      'Template Two',
+      'published',
+    ]);
+    await pool.query('insert into public.program_template_links(template_id, program_id) values ($1,$2)', [
+      templateOne,
+      programId,
+    ]);
+    await pool.query('insert into public.program_template_links(template_id, program_id) values ($1,$2)', [
+      templateTwo,
+      programId,
+    ]);
+
+    const programTemplates = await agent
+      .get(`/api/programs/${programId}/templates`)
+      .query({ limit: 1 })
+      .expect(200);
+
+    expect(programTemplates.body.meta.total).toBe(2);
+    expect(programTemplates.body.data.length).toBe(1);
+
+    const templatePrograms = await agent
+      .get(`/api/templates/${templateOne}/programs`)
+      .query({ limit: 5 })
+      .expect(200);
+
+    expect(templatePrograms.body.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ program_id: programId, title: 'Program' }),
+      ])
+    );
+  });
+
+  test('attach and detach enforce RBAC and remain idempotent', async () => {
+    const adminUsername = 'admin-attach';
+    await createUserWithRole(adminUsername, 'admin');
+    const adminAgent = await loginAgent(adminUsername);
+
+    await grantPermission('template.update');
+
+    const managerUsername = 'manager-attach';
+    const managerId = await createUserWithRole(managerUsername, 'manager');
+    await pool.query('insert into public.program_memberships(user_id, program_id, role) values ($1,$2,$3)', [
+      managerId,
+      'attach-program',
+      'manager',
+    ]);
+
+    const otherManagerUsername = 'manager-no-access';
+    await createUserWithRole(otherManagerUsername, 'manager');
+
+    await pool.query('insert into public.programs(program_id, title) values ($1,$2)', [
+      'attach-program',
+      'Attach Program',
+    ]);
+    const templateId = nextTemplateId();
+    await pool.query('insert into public.program_task_templates(template_id, label) values ($1,$2)', [
+      templateId,
+      'Attach Template',
+    ]);
+
+    const managerAgent = await loginAgent(managerUsername);
+    const otherManagerAgent = await loginAgent(otherManagerUsername);
+
+    let attachRes = await managerAgent
+      .post('/api/programs/attach-program/templates/attach')
+      .send({ template_id: templateId })
+      .expect(200);
+    expect(attachRes.body.attached).toBe(true);
+    expect(attachRes.body.alreadyAttached).toBe(false);
+
+    attachRes = await managerAgent
+      .post('/api/programs/attach-program/templates/attach')
+      .send({ templateId })
+      .expect(200);
+    expect(attachRes.body.alreadyAttached).toBe(true);
+
+    await otherManagerAgent
+      .post('/api/programs/attach-program/templates/attach')
+      .send({ template_id: templateId })
+      .expect(403);
+
+    let detachRes = await managerAgent
+      .post('/api/programs/attach-program/templates/detach')
+      .send({ template_id: templateId })
+      .expect(200);
+    expect(detachRes.body.detached).toBe(true);
+    expect(detachRes.body.wasAttached).toBe(true);
+
+    detachRes = await managerAgent
+      .post('/api/programs/attach-program/templates/detach')
+      .send({ template_id: templateId })
+      .expect(200);
+    expect(detachRes.body.wasAttached).toBe(false);
+
+    const { rows } = await pool.query(
+      'select 1 from public.program_template_links where template_id=$1 and program_id=$2',
+      [templateId, 'attach-program']
+    );
+    expect(rows).toHaveLength(0);
+
+    const programList = await adminAgent
+      .get('/api/programs/attach-program/templates')
+      .query({ include_deleted: 'true' })
+      .expect(200);
+    expect(programList.body.meta.total).toBe(0);
+  });
+});

--- a/db/programTemplateLinks.js
+++ b/db/programTemplateLinks.js
@@ -1,0 +1,209 @@
+'use strict';
+
+const { TEMPLATE_STATUSES, serializeTemplateRow } = require('./templates');
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+const normalizeLimit = value => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.floor(numeric), MAX_LIMIT);
+};
+
+const normalizeOffset = value => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return 0;
+  return Math.floor(numeric);
+};
+
+function createProgramTemplateLinksDao(pool) {
+  const runQuery = (db, text, params) => db.query(text, params);
+
+  const buildStatusFilter = (status, params) => {
+    if (!status || typeof status !== 'string') return '';
+    const normalized = status.trim().toLowerCase();
+    if (!TEMPLATE_STATUSES.has(normalized)) return '';
+    params.push(normalized);
+    return ` and t.status = $${params.length}`;
+  };
+
+  async function listTemplatesForProgram(options = {}) {
+    const {
+      programId,
+      db = pool,
+      limit = DEFAULT_LIMIT,
+      offset = 0,
+      includeDeleted = false,
+      status,
+    } = options;
+    if (!programId) {
+      return { data: [], meta: { total: 0, limit: normalizeLimit(limit), offset: normalizeOffset(offset) } };
+    }
+    const normalizedLimit = normalizeLimit(limit);
+    const normalizedOffset = normalizeOffset(offset);
+    const params = [programId];
+    let where = 'where l.program_id = $1';
+    if (!includeDeleted) {
+      where += ' and t.deleted_at is null';
+    }
+    where += buildStatusFilter(status, params);
+    const filterParams = params.slice();
+    params.push(normalizedLimit);
+    params.push(normalizedOffset);
+    const sql = `
+      select t.template_id,
+             t.week_number,
+             t.label,
+             t.notes,
+             t.sort_order,
+             t.status,
+             t.deleted_at,
+             l.program_id,
+             l.created_at
+        from public.program_template_links l
+        join public.program_task_templates t
+          on t.template_id = l.template_id
+       ${where}
+       order by t.week_number nulls last,
+                t.sort_order nulls last,
+                t.template_id
+       limit $${params.length - 1}
+      offset $${params.length}
+    `;
+    const { rows } = await runQuery(db, sql, params);
+    const countSql = `
+      select count(*) as total
+        from public.program_template_links l
+        join public.program_task_templates t on t.template_id = l.template_id
+       ${where}
+    `;
+    const { rows: countRows } = await runQuery(db, countSql, filterParams);
+    const total = Number(countRows[0]?.total || 0);
+    return {
+      data: rows.map(row => ({
+        ...serializeTemplateRow(row),
+        program_id: row.program_id,
+        linked_at: row.created_at ?? null,
+      })),
+      meta: {
+        total,
+        limit: normalizedLimit,
+        offset: normalizedOffset,
+      },
+    };
+  }
+
+  async function listProgramsForTemplate(options = {}) {
+    const {
+      templateId,
+      db = pool,
+      limit = DEFAULT_LIMIT,
+      offset = 0,
+    } = options;
+    if (!templateId) {
+      return { data: [], meta: { total: 0, limit: normalizeLimit(limit), offset: normalizeOffset(offset) } };
+    }
+    const normalizedLimit = normalizeLimit(limit);
+    const normalizedOffset = normalizeOffset(offset);
+    const params = [templateId];
+    const filterParams = params.slice();
+    params.push(normalizedLimit);
+    params.push(normalizedOffset);
+    const sql = `
+      select p.program_id,
+             p.title,
+             p.deleted_at,
+             l.created_at
+        from public.program_template_links l
+        join public.programs p on p.program_id = l.program_id
+       where l.template_id = $1
+       order by p.title nulls last, p.program_id
+       limit $${params.length - 1}
+      offset $${params.length}
+    `;
+    const { rows } = await runQuery(db, sql, params);
+    const countSql = `
+      select count(*) as total
+        from public.program_template_links l
+       where l.template_id = $1
+    `;
+    const { rows: countRows } = await runQuery(db, countSql, filterParams);
+    const total = Number(countRows[0]?.total || 0);
+    return {
+      data: rows.map(row => ({
+        program_id: row.program_id,
+        title: row.title ?? null,
+        deleted_at: row.deleted_at ?? null,
+        linked_at: row.created_at ?? null,
+      })),
+      meta: {
+        total,
+        limit: normalizedLimit,
+        offset: normalizedOffset,
+      },
+    };
+  }
+
+  async function attach(options = {}) {
+    const { programId, templateId, db = pool } = options;
+    if (!programId || !templateId) {
+      return { attached: false, alreadyAttached: false };
+    }
+    const sql = `
+      insert into public.program_template_links (template_id, program_id)
+      values ($1, $2)
+      on conflict do nothing
+      returning created_at
+    `;
+    const { rowCount, rows } = await runQuery(db, sql, [templateId, programId]);
+    return {
+      attached: true,
+      alreadyAttached: rowCount === 0,
+      linked_at: rows[0]?.created_at ?? null,
+    };
+  }
+
+  async function detach(options = {}) {
+    const { programId, templateId, db = pool } = options;
+    if (!programId || !templateId) {
+      return { detached: false, wasAttached: false };
+    }
+    const sql = `
+      delete from public.program_template_links
+       where template_id = $1
+         and program_id = $2
+    `;
+    const { rowCount } = await runQuery(db, sql, [templateId, programId]);
+    return {
+      detached: true,
+      wasAttached: rowCount > 0,
+    };
+  }
+
+  async function isLinked(options = {}) {
+    const { programId, templateId, db = pool } = options;
+    if (!programId || !templateId) return false;
+    const sql = `
+      select 1
+        from public.program_template_links
+       where template_id = $1
+         and program_id = $2
+       limit 1
+    `;
+    const { rowCount } = await runQuery(db, sql, [templateId, programId]);
+    return rowCount > 0;
+  }
+
+  return {
+    listTemplatesForProgram,
+    listProgramsForTemplate,
+    attach,
+    detach,
+    isLinked,
+  };
+}
+
+module.exports = {
+  createProgramTemplateLinksDao,
+};

--- a/db/templates.js
+++ b/db/templates.js
@@ -1,0 +1,227 @@
+'use strict';
+
+const TEMPLATE_STATUSES = new Set(['draft', 'published', 'deprecated']);
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+const toNumber = value => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') return value;
+  if (typeof value === 'bigint') return Number(value);
+  const asNumber = Number(value);
+  return Number.isNaN(asNumber) ? null : asNumber;
+};
+
+const toTemplateId = value => {
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'bigint') return value.toString();
+  return typeof value === 'number' ? value : String(value);
+};
+
+const normalizeLimit = value => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.floor(numeric), MAX_LIMIT);
+};
+
+const normalizeOffset = value => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) return 0;
+  return Math.floor(numeric);
+};
+
+const serializeTemplateRow = row => ({
+  template_id: toTemplateId(row.template_id),
+  week_number: toNumber(row.week_number),
+  label: row.label ?? null,
+  notes: row.notes ?? null,
+  sort_order: toNumber(row.sort_order),
+  status: row.status ?? null,
+  deleted_at: row.deleted_at ?? null,
+});
+
+function createTemplatesDao(pool) {
+  const runQuery = (db, text, params) => db.query(text, params);
+
+  const withDb = (options = {}) => ({
+    db: options.db ?? pool,
+    limit: normalizeLimit(options.limit ?? DEFAULT_LIMIT),
+    offset: normalizeOffset(options.offset ?? 0),
+    includeDeleted: Boolean(options.includeDeleted),
+    status: options.status,
+    search: options.search,
+  });
+
+  const buildStatusFilter = (status, params) => {
+    if (!status) return '';
+    if (typeof status !== 'string') return '';
+    const normalized = status.trim().toLowerCase();
+    if (!TEMPLATE_STATUSES.has(normalized)) return '';
+    params.push(normalized);
+    return ` and t.status = $${params.length}`;
+  };
+
+  const buildSearchFilter = (search, params) => {
+    if (!search || typeof search !== 'string') return '';
+    const normalized = search.trim();
+    if (!normalized) return '';
+    params.push(`%${normalized.replace(/%/g, '\\%').replace(/_/g, '\\_')}%`);
+    return ` and (t.label ilike $${params.length} or t.notes ilike $${params.length})`;
+  };
+
+  async function list(options = {}) {
+    const { db, limit, offset, includeDeleted, status, search } = withDb(options);
+    const params = [];
+    let where = 'where 1=1';
+    if (!includeDeleted) {
+      where += ' and t.deleted_at is null';
+    }
+    where += buildStatusFilter(status, params);
+    where += buildSearchFilter(search, params);
+    const filterParams = params.slice();
+    params.push(limit);
+    params.push(offset);
+    const sql = `
+      select t.template_id,
+             t.week_number,
+             t.label,
+             t.notes,
+             t.sort_order,
+             t.status,
+             t.deleted_at
+        from public.program_task_templates t
+       ${where}
+       order by t.week_number nulls last,
+                t.sort_order nulls last,
+                t.template_id
+       limit $${params.length - 1}
+      offset $${params.length}
+    `;
+    const { rows } = await runQuery(db, sql, params);
+    const countSql = `
+      select count(*) as total
+        from public.program_task_templates t
+       ${where}
+    `;
+    const { rows: countRows } = await runQuery(db, countSql, filterParams);
+    const total = Number(countRows[0]?.total || 0);
+    return {
+      data: rows.map(serializeTemplateRow),
+      meta: {
+        total,
+        limit,
+        offset,
+      },
+    };
+  }
+
+  async function getById(options = {}) {
+    const { id, includeDeleted = false, db = pool } = options;
+    if (id === undefined || id === null) return null;
+    const params = [id];
+    let where = 'where t.template_id = $1';
+    if (!includeDeleted) {
+      where += ' and t.deleted_at is null';
+    }
+    const sql = `
+      select t.template_id,
+             t.week_number,
+             t.label,
+             t.notes,
+             t.sort_order,
+             t.status,
+             t.deleted_at
+        from public.program_task_templates t
+       ${where}
+       limit 1
+    `;
+    const { rows } = await runQuery(db, sql, params);
+    if (!rows.length) return null;
+    return serializeTemplateRow(rows[0]);
+  }
+
+  async function create(options = {}) {
+    const { db = pool, week_number = null, label, notes = null, sort_order = null, status = 'draft' } = options;
+    const sql = `
+      insert into public.program_task_templates
+        (week_number, label, notes, sort_order, status)
+      values ($1, $2, $3, $4, $5)
+      returning template_id, week_number, label, notes, sort_order, status, deleted_at
+    `;
+    const params = [week_number, label, notes, sort_order, status];
+    const { rows } = await runQuery(db, sql, params);
+    return serializeTemplateRow(rows[0]);
+  }
+
+  async function update(options = {}) {
+    const { id, patch = {}, db = pool } = options;
+    if (!id) return null;
+    const fields = [];
+    const values = [];
+    for (const key of ['week_number', 'label', 'notes', 'sort_order', 'status']) {
+      if (Object.prototype.hasOwnProperty.call(patch, key)) {
+        values.push(patch[key]);
+        fields.push(`${key} = $${values.length}`);
+      }
+    }
+    if (!fields.length) {
+      return getById({ id, includeDeleted: true, db });
+    }
+    values.push(id);
+    const sql = `
+      update public.program_task_templates
+         set ${fields.join(', ')}
+       where template_id = $${values.length}
+       returning template_id, week_number, label, notes, sort_order, status, deleted_at
+    `;
+    const { rows } = await runQuery(db, sql, values);
+    if (!rows.length) return null;
+    return serializeTemplateRow(rows[0]);
+  }
+
+  async function softDelete(options = {}) {
+    const { id, db = pool } = options;
+    if (!id) return null;
+    const sql = `
+      update public.program_task_templates
+         set deleted_at = coalesce(deleted_at, now())
+       where template_id = $1
+         and deleted_at is null
+       returning template_id, week_number, label, notes, sort_order, status, deleted_at
+    `;
+    const { rows } = await runQuery(db, sql, [id]);
+    if (!rows.length) return null;
+    return serializeTemplateRow(rows[0]);
+  }
+
+  async function restore(options = {}) {
+    const { id, db = pool } = options;
+    if (!id) return null;
+    const sql = `
+      update public.program_task_templates
+         set deleted_at = null
+       where template_id = $1
+         and deleted_at is not null
+       returning template_id, week_number, label, notes, sort_order, status, deleted_at
+    `;
+    const { rows } = await runQuery(db, sql, [id]);
+    if (!rows.length) return null;
+    return serializeTemplateRow(rows[0]);
+  }
+
+  return {
+    list,
+    getById,
+    create,
+    update,
+    softDelete,
+    restore,
+  };
+}
+
+module.exports = {
+  createTemplatesDao,
+  TEMPLATE_STATUSES,
+  serializeTemplateRow,
+};

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1,0 +1,427 @@
+openapi: 3.0.3
+info:
+  title: Orientation API
+  version: '1.0.0'
+  description: |
+    API documentation for task template management, including pagination and
+    program associations.
+servers:
+  - url: https://localhost:3002
+paths:
+  /api/templates:
+    get:
+      summary: List task templates
+      tags: [Templates]
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+          description: Maximum number of templates to return.
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+          description: Number of templates to skip before collecting results.
+        - in: query
+          name: include_deleted
+          schema:
+            type: boolean
+          description: Include soft-deleted templates when true.
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [draft, published, deprecated]
+          description: Filter templates by status.
+        - in: query
+          name: search
+          schema:
+            type: string
+          description: Perform case-insensitive search across labels and notes.
+      responses:
+        '200':
+          description: Paginated list of templates.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateListResponse'
+        '400':
+          description: Invalid status or pagination parameter supplied.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.read` permission.
+    post:
+      summary: Create a template
+      tags: [Templates]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TemplateCreateInput'
+      responses:
+        '201':
+          description: Template created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Template'
+        '400':
+          description: Validation error.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.create` permission.
+  /api/templates/{templateId}:
+    parameters:
+      - in: path
+        name: templateId
+        required: true
+        schema:
+          type: string
+        description: Identifier of the template.
+    get:
+      summary: Retrieve a template
+      tags: [Templates]
+      parameters:
+        - in: query
+          name: include_deleted
+          schema:
+            type: boolean
+          description: Include soft-deleted template state.
+      responses:
+        '200':
+          description: Template details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Template'
+        '400':
+          description: Invalid template identifier.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.read` permission.
+        '404':
+          description: Template not found.
+    patch:
+      summary: Update a template
+      tags: [Templates]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TemplateUpdateInput'
+      responses:
+        '200':
+          description: Template updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Template'
+        '400':
+          description: Validation error or missing fields.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.update` permission.
+        '404':
+          description: Template not found or soft deleted.
+    delete:
+      summary: Soft delete a template
+      tags: [Templates]
+      responses:
+        '200':
+          description: Template soft deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  deleted:
+                    type: boolean
+        '400':
+          description: Invalid template identifier.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.delete` permission.
+        '404':
+          description: Template not found or already deleted.
+  /api/templates/{templateId}/restore:
+    post:
+      summary: Restore a soft-deleted template
+      tags: [Templates]
+      responses:
+        '200':
+          description: Template restored successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  restored:
+                    type: boolean
+        '400':
+          description: Invalid template identifier.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.delete` permission.
+        '404':
+          description: Template not found.
+  /api/templates/{templateId}/programs:
+    get:
+      summary: List programs linked to a template
+      tags: [Templates]
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: Paginated list of programs.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateProgramList'
+        '400':
+          description: Invalid template identifier.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.read` permission.
+  /api/programs/{programId}/templates:
+    parameters:
+      - in: path
+        name: programId
+        required: true
+        schema:
+          type: string
+        description: Identifier of the program.
+    get:
+      summary: List templates linked to a program
+      tags: [Programs]
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+        - in: query
+          name: include_deleted
+          schema:
+            type: boolean
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [draft, published, deprecated]
+      responses:
+        '200':
+          description: Paginated list of templates associated with the program.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TemplateListResponse'
+        '400':
+          description: Invalid request parameters.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.read` permission.
+        '404':
+          description: Program not found.
+  /api/programs/{programId}/templates/attach:
+    post:
+      summary: Attach an existing template to a program
+      tags: [Programs]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [template_id]
+              properties:
+                template_id:
+                  type: string
+                  description: Identifier of the template to attach.
+      responses:
+        '200':
+          description: Template attached or already linked.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  attached:
+                    type: boolean
+                  alreadyAttached:
+                    type: boolean
+                  template:
+                    $ref: '#/components/schemas/Template'
+        '400':
+          description: Invalid template identifier.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.update` permission or manager not assigned.
+        '404':
+          description: Program or template not found.
+  /api/programs/{programId}/templates/detach:
+    post:
+      summary: Detach a template from a program
+      tags: [Programs]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [template_id]
+              properties:
+                template_id:
+                  type: string
+                  description: Identifier of the template to detach.
+      responses:
+        '200':
+          description: Template detached if linked.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detached:
+                    type: boolean
+                  wasAttached:
+                    type: boolean
+        '400':
+          description: Invalid template identifier.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.update` permission or manager not assigned.
+        '404':
+          description: Program or template not found.
+components:
+  schemas:
+    Template:
+      type: object
+      properties:
+        template_id:
+          type: string
+        week_number:
+          type: integer
+          nullable: true
+        label:
+          type: string
+        notes:
+          type: string
+          nullable: true
+        sort_order:
+          type: integer
+          nullable: true
+        status:
+          type: string
+          enum: [draft, published, deprecated]
+        deleted_at:
+          type: string
+          format: date-time
+          nullable: true
+    TemplateCreateInput:
+      type: object
+      required: [label]
+      properties:
+        label:
+          type: string
+        week_number:
+          type: integer
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        sort_order:
+          type: integer
+          nullable: true
+        status:
+          type: string
+          enum: [draft, published, deprecated]
+    TemplateUpdateInput:
+      type: object
+      properties:
+        label:
+          type: string
+        week_number:
+          type: integer
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        sort_order:
+          type: integer
+          nullable: true
+        status:
+          type: string
+          enum: [draft, published, deprecated]
+    TemplateListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Template'
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+    TemplateProgramList:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              program_id:
+                type: string
+              title:
+                type: string
+                nullable: true
+              deleted_at:
+                type: string
+                format: date-time
+                nullable: true
+              linked_at:
+                type: string
+                format: date-time
+                nullable: true
+        meta:
+          $ref: '#/components/schemas/PaginationMeta'
+    PaginationMeta:
+      type: object
+      properties:
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer


### PR DESCRIPTION
## Summary
- add data-access modules for templates and program/program template link pagination helpers
- expose REST endpoints under /api/templates and /api/programs/:id/templates with validation, RBAC checks, and transactions
- extend Jest coverage for the new flows and update the OpenAPI reference

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb4b92a8f0832c89022edbd9363abc