### PR TITLE
Add template attach/detach tests and react stub

### DIFF
--- a/__tests__/ProgramsLanding.test.tsx
+++ b/__tests__/ProgramsLanding.test.tsx
@@ -1,0 +1,195 @@
+jest.mock('../src/api', () => ({
+  getPrograms: jest.fn(),
+  publishProgram: jest.fn(),
+  deprecateProgram: jest.fn(),
+  archiveProgram: jest.fn(),
+  restoreProgram: jest.fn(),
+  getProgramTemplates: jest.fn(),
+  searchTemplates: jest.fn(),
+  attachTemplateToProgram: jest.fn(),
+  detachTemplateFromProgram: jest.fn(),
+}));
+
+import type { Program, Template } from '../src/api';
+import type { User } from '../src/rbac';
+import type { ReactStubExports } from '../test-utils/reactStub';
+
+type ProgramsLandingComponent = typeof import('../src/programs/ProgramsLanding').default;
+
+const ReactStub = require('../test-utils/reactStub') as ReactStubExports;
+const ProgramsLanding = require('../src/programs/ProgramsLanding').default as ProgramsLandingComponent;
+const mockedApi = require('../src/api') as jest.Mocked<typeof import('../src/api')>;
+
+const adminUser: User = {
+  id: 'admin',
+  name: 'Admin User',
+  email: 'admin@example.com',
+  roles: ['admin'],
+  status: 'active',
+};
+
+const baseProgram: Program = {
+  id: 'program-1',
+  name: 'Launch Program',
+  version: '1.0',
+  status: 'published',
+  owner: 'Owner',
+  updatedAt: '2024-05-01',
+  assignedCount: 5,
+};
+
+afterEach(() => {
+  ReactStub.__cleanup();
+  jest.clearAllMocks();
+});
+
+const findButtonByText = (container: HTMLElement, text: string) =>
+  Array.from(container.querySelectorAll('button')).find(button => button.textContent?.includes(text)) ?? null;
+
+const expectTemplateCardPresence = (container: HTMLElement, testId: string, templateName: string) => {
+  const cards = Array.from(container.querySelectorAll(`[data-testid="${testId}"]`));
+  return cards.some(card => card.textContent?.includes(templateName));
+};
+
+const switchToTemplatesTab = async (container: HTMLElement) => {
+  const tabButton = findButtonByText(container, 'Templates');
+  if (!tabButton) {
+    throw new Error('Templates tab button not found');
+  }
+  tabButton.dispatchEvent({ type: 'click' } as any);
+  await ReactStub.__waitForIdle();
+};
+
+describe('ProgramsLanding template associations', () => {
+  it('attaches a template and displays success feedback', async () => {
+    const attachedTemplate: Template = {
+      id: 'tmpl-1',
+      programId: baseProgram.id,
+      name: 'Existing Template',
+      category: 'General',
+      updatedAt: '2024-05-10',
+      status: 'published',
+    };
+    const attachableTemplate: Template = {
+      id: 'tmpl-2',
+      programId: '',
+      name: 'New Hire Checklist',
+      category: 'Operations',
+      updatedAt: '2024-05-12',
+      status: 'draft',
+    };
+
+    mockedApi.getPrograms.mockResolvedValue({ data: [baseProgram], meta: { total: 1, page: 1 } });
+    mockedApi.getProgramTemplates
+      .mockResolvedValueOnce({ data: [attachedTemplate] })
+      .mockResolvedValueOnce({ data: [attachedTemplate, { ...attachableTemplate, programId: baseProgram.id }] });
+    mockedApi.searchTemplates
+      .mockResolvedValueOnce({ data: [attachableTemplate] })
+      .mockResolvedValueOnce({ data: [{ ...attachableTemplate, programId: baseProgram.id }] });
+    mockedApi.attachTemplateToProgram.mockImplementation(async () => ({
+      ...attachableTemplate,
+      programId: baseProgram.id,
+    }));
+
+    const { container } = ReactStub.__render(ProgramsLanding, { currentUser: adminUser });
+    await ReactStub.__waitForIdle();
+
+    await switchToTemplatesTab(container);
+
+    expect(mockedApi.getPrograms).toHaveBeenCalled();
+    expect(mockedApi.getProgramTemplates).toHaveBeenCalledWith(baseProgram.id);
+    expect(mockedApi.searchTemplates).toHaveBeenCalled();
+    expect(expectTemplateCardPresence(container, 'attached-template-card', attachedTemplate.name)).toBe(true);
+    expect(expectTemplateCardPresence(container, 'available-template-card', attachableTemplate.name)).toBe(true);
+
+    const attachButton = findButtonByText(container, 'Attach');
+    expect(attachButton).not.toBeNull();
+    attachButton!.dispatchEvent({ type: 'click' } as any);
+
+    await ReactStub.__waitForIdle();
+
+    expect(mockedApi.attachTemplateToProgram).toHaveBeenCalledWith(baseProgram.id, attachableTemplate.id);
+    expect(expectTemplateCardPresence(container, 'attached-template-card', attachableTemplate.name)).toBe(true);
+    expect(expectTemplateCardPresence(container, 'available-template-card', attachableTemplate.name)).toBe(false);
+
+    const feedback = container.querySelector('[role="status"]');
+    expect(feedback?.textContent).toContain('attached');
+  });
+
+  it('detaches a template and refreshes the attached list', async () => {
+    const primaryTemplate: Template = {
+      id: 'tmpl-3',
+      programId: baseProgram.id,
+      name: 'Orientation Pack',
+      category: 'People Ops',
+      updatedAt: '2024-05-01',
+      status: 'published',
+    };
+    const secondaryTemplate: Template = {
+      id: 'tmpl-4',
+      programId: baseProgram.id,
+      name: 'Security Briefing',
+      category: 'Security',
+      updatedAt: '2024-05-03',
+      status: 'published',
+    };
+
+    mockedApi.getPrograms.mockResolvedValue({ data: [baseProgram], meta: { total: 1, page: 1 } });
+    mockedApi.getProgramTemplates
+      .mockResolvedValueOnce({ data: [primaryTemplate, secondaryTemplate] })
+      .mockResolvedValueOnce({ data: [secondaryTemplate] });
+    mockedApi.searchTemplates.mockResolvedValue({ data: [] });
+    mockedApi.detachTemplateFromProgram.mockImplementation(async () => ({
+      ...primaryTemplate,
+      programId: '',
+    }));
+
+    const { container } = ReactStub.__render(ProgramsLanding, { currentUser: adminUser });
+    await ReactStub.__waitForIdle();
+
+    await switchToTemplatesTab(container);
+
+    const detachButton = findButtonByText(container, 'Detach');
+    expect(detachButton).not.toBeNull();
+    detachButton!.dispatchEvent({ type: 'click' } as any);
+
+    await ReactStub.__waitForIdle();
+
+    expect(mockedApi.detachTemplateFromProgram).toHaveBeenCalledWith(baseProgram.id, primaryTemplate.id);
+    expect(expectTemplateCardPresence(container, 'attached-template-card', primaryTemplate.name)).toBe(false);
+    const feedback = container.querySelector('[role="status"]');
+    expect(feedback?.textContent).toContain('detached');
+  });
+
+  it('shows an error message when detaching fails', async () => {
+    const failingTemplate: Template = {
+      id: 'tmpl-5',
+      programId: baseProgram.id,
+      name: 'Critical Template',
+      category: 'Compliance',
+      updatedAt: '2024-05-06',
+      status: 'published',
+    };
+
+    mockedApi.getPrograms.mockResolvedValue({ data: [baseProgram], meta: { total: 1, page: 1 } });
+    mockedApi.getProgramTemplates.mockResolvedValue({ data: [failingTemplate] });
+    mockedApi.searchTemplates.mockResolvedValue({ data: [] });
+    mockedApi.detachTemplateFromProgram.mockRejectedValue(new Error('Network error'));
+
+    const { container } = ReactStub.__render(ProgramsLanding, { currentUser: adminUser });
+    await ReactStub.__waitForIdle();
+
+    await switchToTemplatesTab(container);
+
+    const detachButton = findButtonByText(container, 'Detach');
+    expect(detachButton).not.toBeNull();
+    detachButton!.dispatchEvent({ type: 'click' } as any);
+
+    await ReactStub.__waitForIdle();
+
+    expect(mockedApi.detachTemplateFromProgram).toHaveBeenCalledWith(baseProgram.id, failingTemplate.id);
+    const errorFeedback = container.querySelector('[role="alert"]');
+    expect(errorFeedback?.textContent).toContain('Unable to detach');
+    expect(expectTemplateCardPresence(container, 'attached-template-card', failingTemplate.name)).toBe(true);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,9 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': '<rootDir>/test-utils/esbuild-jest-transform.js',
   },
+  moduleNameMapper: {
+    '^react$': '<rootDir>/test-utils/reactStub.ts',
+  },
   testMatch: [
     '**/__tests__/**/*.{spec,test}.[tj]s?(x)',
     '**/?(*.)+(spec|test).[tj]s?(x)',

--- a/src/programs/ProgramsLanding.tsx
+++ b/src/programs/ProgramsLanding.tsx
@@ -6,6 +6,9 @@ import {
   archiveProgram,
   restoreProgram,
   getProgramTemplates,
+  searchTemplates,
+  attachTemplateToProgram,
+  detachTemplateFromProgram,
   Program,
   Template,
 } from '../api';
@@ -36,7 +39,12 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
   const [programs, setPrograms] = useState<Program[]>([]);
   const [selectedProgramId, setSelectedProgramId] = useState<string | null>(null);
   const [templates, setTemplates] = useState<Template[]>([]);
+  const [availableTemplates, setAvailableTemplates] = useState<Template[]>([]);
+  const [isLoadingTemplates, setIsLoadingTemplates] = useState(false);
+  const [isLoadingAvailable, setIsLoadingAvailable] = useState(false);
+  const [templateSearch, setTemplateSearch] = useState('');
   const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [pendingTemplateAction, setPendingTemplateAction] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<FeedbackState>(null);
 
   const selectedProgram = selectedProgramId
@@ -60,13 +68,43 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
       const targetProgramId = programId ?? selectedProgramId;
       if (!targetProgramId) {
         setTemplates([]);
+        setIsLoadingTemplates(false);
         return [] as Template[];
       }
-      const response = await getProgramTemplates(targetProgramId);
-      setTemplates(response.data);
-      return response.data;
+      setIsLoadingTemplates(true);
+      try {
+        const response = await getProgramTemplates(targetProgramId);
+        setTemplates(response.data);
+        return response.data;
+      } finally {
+        setIsLoadingTemplates(false);
+      }
     },
     [selectedProgramId],
+  );
+
+  const refreshAvailableTemplates = useCallback(
+    async (programId?: string, queryOverride?: string) => {
+      const targetProgramId = programId ?? selectedProgramId;
+      if (!targetProgramId) {
+        setAvailableTemplates([]);
+        setIsLoadingAvailable(false);
+        return [] as Template[];
+      }
+      setIsLoadingAvailable(true);
+      try {
+        const response = await searchTemplates({
+          query: queryOverride ?? templateSearch,
+          programId: targetProgramId,
+        });
+        const attachable = response.data.filter(template => template.programId !== targetProgramId);
+        setAvailableTemplates(attachable);
+        return attachable;
+      } finally {
+        setIsLoadingAvailable(false);
+      }
+    },
+    [selectedProgramId, templateSearch],
   );
 
   useEffect(() => {
@@ -93,6 +131,7 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
     }
     if (!selectedProgramId) {
       setTemplates([]);
+      setIsLoadingTemplates(false);
       return;
     }
 
@@ -103,6 +142,24 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
       });
     });
   }, [tab, selectedProgramId, refreshTemplates]);
+
+  useEffect(() => {
+    if (tab !== 'templates') {
+      return;
+    }
+    if (!selectedProgramId) {
+      setAvailableTemplates([]);
+      setIsLoadingAvailable(false);
+      return;
+    }
+
+    refreshAvailableTemplates(selectedProgramId, templateSearch).catch(error => {
+      setFeedback({
+        type: 'error',
+        message: `Unable to load available templates. ${getErrorMessage(error)}`,
+      });
+    });
+  }, [tab, selectedProgramId, templateSearch, refreshAvailableTemplates]);
 
   const handleProgramAction = async (program: Program, action: ProgramAction) => {
     const actionKey = `${action}:${program.id}`;
@@ -127,6 +184,59 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
       });
     } finally {
       setPendingAction(prev => (prev === actionKey ? null : prev));
+    }
+  };
+
+  const templateActionKey = (action: 'attach' | 'detach', templateId: string) =>
+    `${action}:${templateId}`;
+
+  const handleAttachTemplate = async (template: Template) => {
+    if (!selectedProgramId) {
+      return;
+    }
+    const actionKey = templateActionKey('attach', template.id);
+    setPendingTemplateAction(actionKey);
+    setFeedback(null);
+    try {
+      const result = await attachTemplateToProgram(selectedProgramId, template.id);
+      await refreshTemplates(selectedProgramId);
+      await refreshAvailableTemplates(selectedProgramId);
+      setFeedback({
+        type: 'success',
+        message: `${result.name} attached to ${selectedProgram?.name ?? 'the program'}.`,
+      });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: `Unable to attach ${template.name}. ${getErrorMessage(error)}`,
+      });
+    } finally {
+      setPendingTemplateAction(prev => (prev === actionKey ? null : prev));
+    }
+  };
+
+  const handleDetachTemplate = async (template: Template) => {
+    if (!selectedProgramId) {
+      return;
+    }
+    const actionKey = templateActionKey('detach', template.id);
+    setPendingTemplateAction(actionKey);
+    setFeedback(null);
+    try {
+      await detachTemplateFromProgram(selectedProgramId, template.id);
+      await refreshTemplates(selectedProgramId);
+      await refreshAvailableTemplates(selectedProgramId);
+      setFeedback({
+        type: 'success',
+        message: `${template.name} detached from ${selectedProgram?.name ?? 'the program'}.`,
+      });
+    } catch (error) {
+      setFeedback({
+        type: 'error',
+        message: `Unable to detach ${template.name}. ${getErrorMessage(error)}`,
+      });
+    } finally {
+      setPendingTemplateAction(prev => (prev === actionKey ? null : prev));
     }
   };
 
@@ -274,7 +384,12 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
         <section className="space-y-4">
           <div className="panel flex flex-col gap-3 p-4 md:flex-row md:items-center md:justify-between">
             <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
-              <input className="form-field md:w-64" placeholder="Search templates" />
+              <input
+                className="form-field md:w-64"
+                placeholder="Search templates"
+                value={templateSearch}
+                onChange={event => setTemplateSearch(event.target.value)}
+              />
               {programs.length > 0 ? (
                 <div className="flex flex-col text-sm">
                   <label htmlFor="template-program-filter" className="text-[var(--text-muted)]">
@@ -309,44 +424,128 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
               </button>
             )}
           </div>
-          {templates.length > 0 ? (
-            <div className="grid gap-4 md:grid-cols-3">
-              {templates.map(template => (
-                <div key={template.id} className="panel space-y-3 p-4">
-                  <div className="flex items-start justify-between gap-2">
-                    <div>
-                      <h3 className="font-semibold">{template.name}</h3>
-                      <p className="text-sm text-[var(--text-muted)]">{template.category}</p>
-                    </div>
-                    {template.status && (
-                      <span className="badge bg-[var(--surface-alt)] text-xs uppercase tracking-wide text-[var(--text-muted)]">
-                        {template.status}
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-sm">Updated: {template.updatedAt || '--'}</p>
-                  <div className="flex flex-wrap gap-2 pt-2">
-                    {can(currentUser, 'update', 'template') && (
-                      <button type="button" className="btn btn-outline text-sm">
-                        Edit
-                      </button>
-                    )}
-                    {can(currentUser, 'delete', 'template') && (
-                      <button type="button" className="btn btn-outline text-sm">
-                        Delete
-                      </button>
-                    )}
-                  </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <section className="space-y-3" data-testid="attached-templates-section">
+              <h2 className="text-lg font-semibold">Attached templates</h2>
+              {isLoadingTemplates ? (
+                <div className="panel p-4 text-sm text-[var(--text-muted)]" data-testid="attached-loading">
+                  Loading templates…
                 </div>
-              ))}
-            </div>
-          ) : (
-            <div className="panel p-4 text-sm text-[var(--text-muted)]">
-              {programs.length === 0
-                ? 'Create a program to view its templates.'
-                : `No templates for ${selectedProgram?.name ?? 'this program'} yet.`}
-            </div>
-          )}
+              ) : templates.length > 0 ? (
+                <div className="grid gap-4" data-testid="attached-templates">
+                  {templates.map(template => {
+                    const detachActionKey = templateActionKey('detach', template.id);
+                    return (
+                      <div
+                        key={template.id}
+                        className="panel space-y-3 p-4"
+                        data-testid="attached-template-card"
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <h3 className="font-semibold">{template.name}</h3>
+                            <p className="text-sm text-[var(--text-muted)]">{template.category}</p>
+                          </div>
+                          {template.status && (
+                            <span className="badge bg-[var(--surface-alt)] text-xs uppercase tracking-wide text-[var(--text-muted)]">
+                              {template.status}
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-sm">Updated: {template.updatedAt || '--'}</p>
+                        <div className="flex flex-wrap gap-2 pt-2">
+                          {can(currentUser, 'update', 'template') && (
+                            <button type="button" className="btn btn-outline text-sm">
+                              Edit
+                            </button>
+                          )}
+                          {can(currentUser, 'delete', 'template') && (
+                            <button type="button" className="btn btn-outline text-sm">
+                              Delete
+                            </button>
+                          )}
+                          {can(currentUser, 'update', 'template') && (
+                            <button
+                              type="button"
+                              className="btn btn-outline text-sm"
+                              onClick={() => handleDetachTemplate(template)}
+                              disabled={pendingTemplateAction === detachActionKey}
+                            >
+                              {pendingTemplateAction === detachActionKey ? 'Detaching…' : 'Detach'}
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="panel p-4 text-sm text-[var(--text-muted)]" data-testid="attached-empty">
+                  {programs.length === 0
+                    ? 'Create a program to view its templates.'
+                    : `No templates for ${selectedProgram?.name ?? 'this program'} yet.`}
+                </div>
+              )}
+            </section>
+            <section className="space-y-3" data-testid="available-templates-section">
+              <h2 className="text-lg font-semibold">Available templates</h2>
+              {isLoadingAvailable ? (
+                <div className="panel p-4 text-sm text-[var(--text-muted)]" data-testid="available-loading">
+                  Searching templates…
+                </div>
+              ) : availableTemplates.length > 0 ? (
+                <div className="grid gap-4" data-testid="available-templates">
+                  {availableTemplates.map(template => {
+                    const attachActionKey = templateActionKey('attach', template.id);
+                    return (
+                      <div
+                        key={template.id}
+                        className="panel space-y-3 p-4"
+                        data-testid="available-template-card"
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <h3 className="font-semibold">{template.name}</h3>
+                            <p className="text-sm text-[var(--text-muted)]">{template.category}</p>
+                          </div>
+                          {template.status && (
+                            <span className="badge bg-[var(--surface-alt)] text-xs uppercase tracking-wide text-[var(--text-muted)]">
+                              {template.status}
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-sm">Updated: {template.updatedAt || '--'}</p>
+                        <div className="flex flex-wrap gap-2 pt-2">
+                          {can(currentUser, 'update', 'template') ? (
+                            <button
+                              type="button"
+                              className="btn btn-primary text-sm"
+                              onClick={() => handleAttachTemplate(template)}
+                              disabled={!selectedProgramId || pendingTemplateAction === attachActionKey}
+                            >
+                              {pendingTemplateAction === attachActionKey ? 'Attaching…' : 'Attach'}
+                            </button>
+                          ) : (
+                            <span className="text-sm text-[var(--text-muted)]">
+                              You do not have permission to attach templates.
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="panel p-4 text-sm text-[var(--text-muted)]" data-testid="available-empty">
+                  {!selectedProgramId
+                    ? 'Select a program to browse attachable templates.'
+                    : templateSearch
+                        ? 'No templates match your search.'
+                        : 'No templates available to attach.'}
+                </div>
+              )}
+            </section>
+          </div>
         </section>
       )}
 

--- a/test-utils/reactStub.ts
+++ b/test-utils/reactStub.ts
@@ -1,0 +1,372 @@
+import { createSimpleDocument, SimpleElement, SimpleText } from './simpleDom';
+
+const Fragment = Symbol('Fragment');
+
+type EffectEntry = { deps?: any[]; cleanup?: (() => void) | void };
+type CallbackEntry = { deps?: any[]; value: any };
+
+type TemplateChild = any;
+
+type ElementType = string | typeof Fragment | ((props: any) => any);
+
+type ElementNode = {
+  type: ElementType;
+  props: Record<string, any> | null;
+};
+
+let currentInstance: ComponentInstance | null = null;
+
+const dom = createSimpleDocument();
+
+let pendingTasks = 0;
+const waiters: (() => void)[] = [];
+
+const notifyWaiters = () => {
+  if (pendingTasks === 0) {
+    while (waiters.length) {
+      const resolve = waiters.shift();
+      if (resolve) resolve();
+    }
+  }
+};
+
+const scheduleTask = (fn: () => void) => {
+  pendingTasks += 1;
+  Promise.resolve()
+    .then(fn)
+    .catch(error => {
+      setTimeout(() => {
+        throw error;
+      }, 0);
+    })
+    .finally(() => {
+      pendingTasks -= 1;
+      notifyWaiters();
+    });
+};
+
+const waitForIdle = () => (pendingTasks === 0 ? Promise.resolve() : new Promise<void>(resolve => waiters.push(resolve)));
+
+const flattenChildren = (children: TemplateChild[]): TemplateChild[] => {
+  const result: TemplateChild[] = [];
+  children.forEach(child => {
+    if (Array.isArray(child)) {
+      result.push(...flattenChildren(child));
+    } else {
+      result.push(child);
+    }
+  });
+  return result;
+};
+
+const createElement = (type: ElementType, props: Record<string, any> | null, ...children: TemplateChild[]): ElementNode => {
+  const normalizedProps = props ? { ...props } : {};
+  if (children.length > 0) {
+    const flatChildren = flattenChildren(children);
+    normalizedProps.children = flatChildren.length === 1 ? flatChildren[0] : flatChildren;
+  }
+  return { type, props: normalizedProps };
+};
+
+const applyProps = (node: SimpleElement, props: Record<string, any>) => {
+  Object.entries(props).forEach(([key, value]) => {
+    if (key === 'children' || value === undefined || value === null) {
+      return;
+    }
+    if (key === 'className') {
+      node.className = String(value);
+      return;
+    }
+    if (key === 'htmlFor') {
+      node.setAttribute('for', String(value));
+      return;
+    }
+    if (key === 'value') {
+      node.value = String(value);
+      return;
+    }
+    if (key === 'disabled') {
+      node.disabled = Boolean(value);
+      return;
+    }
+    if (key.startsWith('on') && typeof value === 'function') {
+      const eventName = key.slice(2).toLowerCase();
+      node.addEventListener(eventName, value as (event: { type: string }) => void);
+      return;
+    }
+    if (key.startsWith('aria') || key.startsWith('data')) {
+      node.setAttribute(key, String(value));
+      return;
+    }
+    if (typeof value === 'boolean') {
+      if (value) {
+        node.setAttribute(key.toLowerCase(), '');
+      } else {
+        node.removeAttribute(key.toLowerCase());
+      }
+      return;
+    }
+    const attrName = key.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`);
+    node.setAttribute(attrName, String(value));
+  });
+};
+
+const mountElement = (element: any, parent: SimpleElement) => {
+  if (element === null || element === undefined || typeof element === 'boolean') {
+    return;
+  }
+  if (Array.isArray(element)) {
+    element.forEach(child => mountElement(child, parent));
+    return;
+  }
+  if (typeof element === 'string' || typeof element === 'number') {
+    parent.appendChild(dom.createTextNode(String(element)));
+    return;
+  }
+  if (typeof element.type === 'function') {
+    const rendered = element.type({ ...(element.props || {}), children: element.props?.children });
+    mountElement(rendered, parent);
+    return;
+  }
+  if (element.type === Fragment) {
+    mountElement(element.props?.children, parent);
+    return;
+  }
+  const node = dom.createElement(element.type as string);
+  if (element.props) {
+    applyProps(node, element.props);
+  }
+  const child = element.props?.children;
+  if (child !== undefined) {
+    mountElement(child, node);
+  }
+  parent.appendChild(node);
+};
+
+class ComponentInstance {
+  component: (props: any) => any;
+  props: any;
+  container: SimpleElement;
+  stateValues: any[] = [];
+  callbackValues: CallbackEntry[] = [];
+  memoValues: CallbackEntry[] = [];
+  effectEntries: EffectEntry[] = [];
+  stateIndex = 0;
+  callbackIndex = 0;
+  memoIndex = 0;
+  effectIndex = 0;
+  pendingRender = false;
+  pendingEffects: { index: number; effect: () => void }[] = [];
+  isMounted = true;
+
+  constructor(component: (props: any) => any, props: any, container: SimpleElement) {
+    this.component = component;
+    this.props = props;
+    this.container = container;
+  }
+
+  render() {
+    if (!this.isMounted) return;
+    this.pendingRender = false;
+    this.stateIndex = 0;
+    this.callbackIndex = 0;
+    this.memoIndex = 0;
+    this.effectIndex = 0;
+    this.pendingEffects = [];
+    currentInstance = this;
+    const output = this.component(this.props);
+    currentInstance = null;
+    this.container.innerHTML = '';
+    mountElement(output, this.container);
+    this.flushEffects();
+  }
+
+  scheduleRender() {
+    if (!this.isMounted || this.pendingRender) {
+      return;
+    }
+    this.pendingRender = true;
+    scheduleTask(() => {
+      if (!this.isMounted) {
+        return;
+      }
+      this.render();
+    });
+  }
+
+  registerEffect(effect: () => void, deps?: any[]) {
+    const index = this.effectIndex++;
+    const previous = this.effectEntries[index];
+    let shouldRun = false;
+    if (!previous) {
+      shouldRun = true;
+    } else if (!deps) {
+      shouldRun = true;
+    } else if (!previous.deps) {
+      shouldRun = true;
+    } else if (previous.deps.length !== deps.length) {
+      shouldRun = true;
+    } else {
+      shouldRun = deps.some((dep, depIndex) => !Object.is(dep, previous.deps?.[depIndex]));
+    }
+    this.effectEntries[index] = { deps };
+    if (shouldRun) {
+      if (previous?.cleanup) {
+        previous.cleanup();
+      }
+      this.pendingEffects.push({ index, effect });
+    }
+  }
+
+  flushEffects() {
+    if (this.pendingEffects.length === 0) {
+      return;
+    }
+    const effects = this.pendingEffects.splice(0);
+    effects.forEach(({ index, effect }) => {
+      scheduleTask(() => {
+        if (!this.isMounted) {
+          return;
+        }
+        const cleanup = effect();
+        this.effectEntries[index] = {
+          deps: this.effectEntries[index]?.deps,
+          cleanup: typeof cleanup === 'function' ? cleanup : undefined,
+        };
+      });
+    });
+  }
+
+  unmount() {
+    if (!this.isMounted) return;
+    this.isMounted = false;
+    this.effectEntries.forEach(entry => {
+      if (entry?.cleanup) {
+        entry.cleanup();
+      }
+    });
+    this.container.remove();
+  }
+}
+
+const assertInstance = () => {
+  if (!currentInstance) {
+    throw new Error('Hooks can only be called inside a component.');
+  }
+  return currentInstance;
+};
+
+const useState = <T,>(initial: T | (() => T)): [T, (value: T | ((prev: T) => T)) => void] => {
+  const instance = assertInstance();
+  const index = instance.stateIndex++;
+  if (instance.stateValues[index] === undefined) {
+    instance.stateValues[index] = typeof initial === 'function' ? (initial as () => T)() : initial;
+  }
+  const setState = (value: T | ((prev: T) => T)) => {
+    const current = instance.stateValues[index];
+    const next = typeof value === 'function' ? (value as (prev: T) => T)(current) : value;
+    if (!Object.is(current, next)) {
+      instance.stateValues[index] = next;
+      instance.scheduleRender();
+    }
+  };
+  return [instance.stateValues[index] as T, setState];
+};
+
+const useCallback = <T extends (...args: any[]) => any>(callback: T, deps?: any[]): T => {
+  const instance = assertInstance();
+  const index = instance.callbackIndex++;
+  const previous = instance.callbackValues[index];
+  let shouldStore = true;
+  if (previous && deps && previous.deps && previous.deps.length === deps.length) {
+    shouldStore = deps.some((dep, depIndex) => !Object.is(dep, previous.deps?.[depIndex]));
+  }
+  if (!previous) {
+    shouldStore = true;
+  }
+  if (!deps) {
+    shouldStore = true;
+  }
+  if (shouldStore) {
+    instance.callbackValues[index] = { deps, value: callback };
+  }
+  return (instance.callbackValues[index]?.value ?? callback) as T;
+};
+
+const useMemo = <T,>(factory: () => T, deps?: any[]): T => {
+  const instance = assertInstance();
+  const index = instance.memoIndex++;
+  const previous = instance.memoValues[index];
+  if (!previous) {
+    const initialValue = factory();
+    instance.memoValues[index] = { deps, value: initialValue };
+    return initialValue;
+  }
+  let shouldRecompute = false;
+  if (!deps) {
+    shouldRecompute = true;
+  } else if (!previous.deps) {
+    shouldRecompute = true;
+  } else if (previous.deps.length !== deps.length) {
+    shouldRecompute = true;
+  } else {
+    shouldRecompute = deps.some((dep, depIndex) => !Object.is(dep, previous.deps?.[depIndex]));
+  }
+  if (shouldRecompute) {
+    const value = factory();
+    instance.memoValues[index] = { deps, value };
+    return value;
+  }
+  return previous.value;
+};
+
+const useEffect = (effect: () => void | (() => void), deps?: any[]) => {
+  const instance = assertInstance();
+  instance.registerEffect(effect, deps);
+};
+
+const instances = new Set<ComponentInstance>();
+
+const renderComponent = (component: (props: any) => any, props: any = {}) => {
+  const container = dom.createElement('div');
+  dom.body.appendChild(container);
+  const instance = new ComponentInstance(component, props, container);
+  instances.add(instance);
+  instance.render();
+  return {
+    container,
+    rerender(nextProps: Record<string, any> = {}) {
+      instance.props = { ...instance.props, ...nextProps };
+      instance.scheduleRender();
+    },
+    unmount() {
+      instance.unmount();
+      instances.delete(instance);
+    },
+  };
+};
+
+const cleanup = () => {
+  instances.forEach(instance => instance.unmount());
+  instances.clear();
+  dom.body.innerHTML = '';
+};
+
+const defaultExport = Object.assign(
+  { createElement, Fragment },
+  {
+    useState,
+    useEffect,
+    useCallback,
+    useMemo,
+    __render: renderComponent,
+    __waitForIdle: waitForIdle,
+    __cleanup: cleanup,
+  },
+);
+
+export type ReactStubExports = typeof defaultExport;
+
+export { Fragment, createElement, useState, useEffect, useCallback, useMemo, renderComponent as __render, waitForIdle as __waitForIdle, cleanup as __cleanup };
+
+export default defaultExport;

--- a/test-utils/simpleDom.ts
+++ b/test-utils/simpleDom.ts
@@ -1,0 +1,189 @@
+export type SimpleEventHandler = (event: { type: string }) => void;
+
+class SimpleNode {
+  parent: SimpleElement | null = null;
+}
+
+export class SimpleText extends SimpleNode {
+  private value: string;
+
+  constructor(text: string) {
+    super();
+    this.value = text;
+  }
+
+  get textContent(): string {
+    return this.value;
+  }
+
+  set textContent(value: string) {
+    this.value = value;
+  }
+}
+
+export class SimpleElement extends SimpleNode {
+  readonly tagName: string;
+  private attributes = new Map<string, string>();
+  private childrenNodes: (SimpleElement | SimpleText)[] = [];
+  private listeners = new Map<string, SimpleEventHandler[]>();
+
+  constructor(tag: string) {
+    super();
+    this.tagName = tag.toLowerCase();
+  }
+
+  appendChild<T extends SimpleElement | SimpleText>(child: T): T {
+    if (child.parent) {
+      child.parent.removeChild(child);
+    }
+    child.parent = this;
+    this.childrenNodes.push(child);
+    return child;
+  }
+
+  removeChild(child: SimpleElement | SimpleText) {
+    const index = this.childrenNodes.indexOf(child);
+    if (index >= 0) {
+      this.childrenNodes.splice(index, 1);
+      child.parent = null;
+    }
+  }
+
+  remove() {
+    if (this.parent) {
+      this.parent.removeChild(this);
+    }
+  }
+
+  setAttribute(name: string, value: string) {
+    const normalized = name.toLowerCase();
+    this.attributes.set(normalized, String(value));
+    if (normalized === 'class') {
+      this.attributes.set('class', String(value));
+    }
+  }
+
+  getAttribute(name: string): string | undefined {
+    return this.attributes.get(name.toLowerCase());
+  }
+
+  removeAttribute(name: string) {
+    this.attributes.delete(name.toLowerCase());
+  }
+
+  addEventListener(type: string, handler: SimpleEventHandler) {
+    const normalized = type.toLowerCase();
+    if (!this.listeners.has(normalized)) {
+      this.listeners.set(normalized, []);
+    }
+    this.listeners.get(normalized)!.push(handler);
+  }
+
+  dispatchEvent(event: { type: string }) {
+    const normalized = event.type.toLowerCase();
+    const handlers = this.listeners.get(normalized) ?? [];
+    handlers.forEach(handler => handler.call(this, event));
+    return handlers.length > 0;
+  }
+
+  querySelectorAll(selector: string): SimpleElement[] {
+    const results: SimpleElement[] = [];
+    const normalized = selector.trim();
+    const match = (element: SimpleElement) => {
+      if (normalized.startsWith('[') && normalized.endsWith(']')) {
+        const inner = normalized.slice(1, -1);
+        const [attrName, rawValue] = inner.split('=');
+        const attribute = attrName.trim();
+        const expected = rawValue ? rawValue.replace(/^"|"$/g, '') : undefined;
+        const actual = element.getAttribute(attribute);
+        if (expected === undefined) {
+          return actual !== undefined;
+        }
+        return actual === expected;
+      }
+      return element.tagName === normalized.toLowerCase();
+    };
+
+    const walk = (node: SimpleElement | SimpleText) => {
+      if (node instanceof SimpleElement) {
+        if (match(node)) {
+          results.push(node);
+        }
+        node.childrenNodes.forEach(child => walk(child));
+      }
+    };
+
+    this.childrenNodes.forEach(child => walk(child));
+    return results;
+  }
+
+  querySelector(selector: string): SimpleElement | null {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+
+  get className(): string {
+    return this.getAttribute('class') ?? '';
+  }
+
+  set className(value: string) {
+    this.setAttribute('class', value);
+  }
+
+  get value(): string {
+    return this.getAttribute('value') ?? '';
+  }
+
+  set value(value: string) {
+    this.setAttribute('value', value);
+  }
+
+  get disabled(): boolean {
+    return this.attributes.has('disabled');
+  }
+
+  set disabled(value: boolean) {
+    if (value) {
+      this.attributes.set('disabled', '');
+    } else {
+      this.attributes.delete('disabled');
+    }
+  }
+
+  get textContent(): string {
+    return this.childrenNodes.map(child => child.textContent).join('');
+  }
+
+  set textContent(value: string) {
+    this.childrenNodes = [new SimpleText(value)];
+  }
+
+  set innerHTML(value: string) {
+    if (!value) {
+      this.childrenNodes = [];
+      return;
+    }
+    this.childrenNodes = [new SimpleText(value)];
+  }
+
+  get children(): (SimpleElement | SimpleText)[] {
+    return this.childrenNodes.slice();
+  }
+}
+
+export class SimpleDocument {
+  readonly body: SimpleElement;
+
+  constructor() {
+    this.body = new SimpleElement('body');
+  }
+
+  createElement(tag: string): SimpleElement {
+    return new SimpleElement(tag);
+  }
+
+  createTextNode(text: string): SimpleText {
+    return new SimpleText(text);
+  }
+}
+
+export const createSimpleDocument = () => new SimpleDocument();


### PR DESCRIPTION
## Summary
- add client helpers for searching templates and attaching/detaching them, plus mock data updates
- expand ProgramsLanding with attachable template UI, handlers, and feedback states
- introduce a React test stub/simple DOM and add coverage for attaching/detaching templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cc3b8c72f4832c9432b9e3d4c0a0f1