### PR TITLE
Fix template selection state in assignments panel

### DIFF
--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -4541,7 +4541,7 @@ if (programTemplateList) {
     handleAssociationFieldChange(templateId, field, target);
   });
 
-  programTemplateList.addEventListener('click', event => {
+  programTemplateList.addEventListener('click', async event => {
     const target = event.target instanceof HTMLElement ? event.target : null;
     if (!target) return;
     const actionBtn = target.closest('[data-assignment-action]');
@@ -4568,11 +4568,22 @@ if (programTemplateList) {
     const item = target.closest('li[data-template-id]');
     if (!item) return;
     const templateId = item.getAttribute('data-template-id');
-    if (!templateId) return;
+    if (!templateId || selectedTemplateId === templateId) return;
+    try {
+      await flushPendingTemplateAssociationChanges();
+    } catch (error) {
+      console.error(error);
+    }
+    destroyTemplateProgramTagifyInstance();
     selectedTemplateIds.clear();
     selectedTemplateIds.add(templateId);
     selectedTemplateId = templateId;
+    selectedTemplateProgramIds.clear();
+    selectedTemplateProgramId = null;
+    templatePrograms = [];
+    isLoadingTemplatePrograms = true;
     renderTemplates();
+    loadTemplateProgramAssociations({ preserveSelection: true }).catch(() => {});
   });
 }
 


### PR DESCRIPTION
## Summary
- await pending template association changes before switching selections from the sidebar
- reset template program state and reload associations when choosing a new template from the assignments list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc5744e0b8832c88674c70d8725a74