### PR TITLE
Extend program template link metadata

### DIFF
--- a/migrations/010_program_template_links_extend.sql
+++ b/migrations/010_program_template_links_extend.sql
@@ -1,0 +1,77 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+ALTER TABLE IF EXISTS public.program_template_links
+  ADD COLUMN IF NOT EXISTS id uuid DEFAULT gen_random_uuid(),
+  ADD COLUMN IF NOT EXISTS week_number integer,
+  ADD COLUMN IF NOT EXISTS sort_order integer,
+  ADD COLUMN IF NOT EXISTS due_offset_days integer,
+  ADD COLUMN IF NOT EXISTS required boolean,
+  ADD COLUMN IF NOT EXISTS visibility text,
+  ADD COLUMN IF NOT EXISTS visible boolean DEFAULT true,
+  ADD COLUMN IF NOT EXISTS notes text,
+  ADD COLUMN IF NOT EXISTS created_by uuid REFERENCES public.users(id),
+  ADD COLUMN IF NOT EXISTS updated_by uuid REFERENCES public.users(id),
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now();
+
+ALTER TABLE public.program_template_links
+  ALTER COLUMN id SET NOT NULL,
+  ALTER COLUMN id SET DEFAULT gen_random_uuid(),
+  ALTER COLUMN updated_at SET DEFAULT now(),
+  ALTER COLUMN visible SET DEFAULT true;
+
+ALTER TABLE public.program_template_links
+  DROP CONSTRAINT IF EXISTS program_template_links_pkey;
+
+ALTER TABLE public.program_template_links
+  ADD CONSTRAINT program_template_links_pkey PRIMARY KEY (id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conname = 'program_template_links_program_template_key'
+       AND conrelid = 'public.program_template_links'::regclass
+  ) THEN
+    ALTER TABLE public.program_template_links
+      ADD CONSTRAINT program_template_links_program_template_key UNIQUE (program_id, template_id);
+  END IF;
+END$$;
+
+UPDATE public.program_template_links AS l
+   SET week_number = COALESCE(l.week_number, t.week_number),
+       sort_order = COALESCE(l.sort_order, t.sort_order),
+       due_offset_days = COALESCE(l.due_offset_days, t.due_offset_days),
+       required = COALESCE(l.required, t.required),
+       visibility = COALESCE(l.visibility, t.visibility),
+       notes = COALESCE(l.notes, t.notes)
+  FROM public.program_task_templates AS t
+ WHERE t.template_id = l.template_id;
+
+UPDATE public.program_template_links
+   SET visible = COALESCE(visible, true);
+
+UPDATE public.program_template_links
+   SET updated_at = COALESCE(updated_at, created_at);
+
+CREATE OR REPLACE FUNCTION public.set_program_template_links_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_program_template_links_updated_at
+  ON public.program_template_links;
+
+CREATE TRIGGER set_program_template_links_updated_at
+BEFORE UPDATE ON public.program_template_links
+FOR EACH ROW
+EXECUTE FUNCTION public.set_program_template_links_updated_at();
+
+COMMIT;

--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -171,6 +171,7 @@ function normalizeTemplateAssociation(raw, index = 0) {
   const source = raw && typeof raw === 'object' ? raw : {};
   const normalized = { ...source };
   const nestedTemplate = source.template && typeof source.template === 'object' ? source.template : null;
+  const linkMeta = source.link && typeof source.link === 'object' ? source.link : null;
   const templateId = getTemplateId(source) || (nestedTemplate ? getTemplateId(nestedTemplate) : null);
   if (templateId && !normalized.templateId) {
     normalized.templateId = templateId;
@@ -178,17 +179,35 @@ function normalizeTemplateAssociation(raw, index = 0) {
   if (!normalized.id && templateId) {
     normalized.id = templateId;
   }
+  const linkId = source.link_id ?? source.linkId ?? linkMeta?.id ?? null;
+  if (linkId && !normalized.link_id) {
+    normalized.link_id = linkId;
+  }
+  if (linkId && !normalized.linkId) {
+    normalized.linkId = linkId;
+  }
+
+  const weekSource = source.week_number
+    ?? linkMeta?.week_number
+    ?? source.weekNumber
+    ?? source.week
+    ?? (nestedTemplate ? nestedTemplate.week_number ?? nestedTemplate.weekNumber ?? nestedTemplate.week : null);
+  const weekNumber = toNullableNumber(weekSource);
+  normalized.week_number = weekNumber;
+  normalized.weekNumber = weekNumber;
 
   const dueOffsetSource = source.due_offset_days
+    ?? linkMeta?.due_offset_days
     ?? source.dueOffsetDays
     ?? source.due_in_days
     ?? source.dueOffset
-    ?? null;
+    ?? (nestedTemplate ? nestedTemplate.due_offset_days : null);
   const dueOffsetDays = toNullableNumber(dueOffsetSource);
   normalized.due_offset_days = dueOffsetDays;
   normalized.dueOffsetDays = dueOffsetDays;
 
   const requiredSource = source.required
+    ?? linkMeta?.required
     ?? source.is_required
     ?? source.isRequired
     ?? (nestedTemplate ? nestedTemplate.required : null);
@@ -196,6 +215,7 @@ function normalizeTemplateAssociation(raw, index = 0) {
   normalized.required = required;
 
   const visibilitySource = source.visibility
+    ?? linkMeta?.visibility
     ?? source.visible_to
     ?? source.visibleTo
     ?? source.audience
@@ -205,7 +225,12 @@ function normalizeTemplateAssociation(raw, index = 0) {
     : String(visibilitySource);
   normalized.visibility = visibility;
 
+  const visibleSource = source.visible ?? linkMeta?.visible;
+  const visible = visibleSource === null || visibleSource === undefined ? null : toNullableBoolean(visibleSource);
+  normalized.visible = visible;
+
   const notesSource = source.notes
+    ?? linkMeta?.notes
     ?? (nestedTemplate ? nestedTemplate.notes : null)
     ?? source.description
     ?? source.summary
@@ -213,6 +238,7 @@ function normalizeTemplateAssociation(raw, index = 0) {
   normalized.notes = notesSource === null || notesSource === undefined ? '' : String(notesSource);
 
   const sortSource = source.sort_order
+    ?? linkMeta?.sort_order
     ?? source.sortOrder
     ?? source.order
     ?? source.position
@@ -222,6 +248,16 @@ function normalizeTemplateAssociation(raw, index = 0) {
   const fallbackSort = index + 1;
   normalized.sort_order = typeof sortValue === 'number' && Number.isFinite(sortValue) ? sortValue : fallbackSort;
   normalized.sortOrder = normalized.sort_order;
+
+  if (!normalized.created_by && (source.created_by || linkMeta?.created_by)) {
+    normalized.created_by = source.created_by ?? linkMeta?.created_by ?? null;
+  }
+  if (!normalized.updated_by && (source.updated_by || linkMeta?.updated_by)) {
+    normalized.updated_by = source.updated_by ?? linkMeta?.updated_by ?? null;
+  }
+  if (!normalized.updated_at && (source.updated_at || linkMeta?.updated_at)) {
+    normalized.updated_at = source.updated_at ?? linkMeta?.updated_at ?? null;
+  }
 
   return normalized;
 }


### PR DESCRIPTION
## Summary
- add a migration that promotes metadata columns onto program_template_links with UUID ids, defaults, and triggers
- update the template link DAO, server routes, and admin UI to read/write the new link-level metadata
- refresh API and route tests to cover per-program metadata updates and idempotent attaches

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cca9ee2020832cb8689d7459037a00