### PR TITLE
Add RESTful program template endpoints

### DIFF
--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -970,7 +970,7 @@ async function flushPendingTemplateAttachments({ immediate = false } = {}) {
         const basePayload = state?.payload && typeof state.payload === 'object' ? state.payload : {};
         const payload = { template_id: id, ...basePayload };
         try {
-          const result = await fetchJson(`${API}/api/programs/${encodeURIComponent(programId)}/templates/attach`, {
+          const result = await fetchJson(`${API}/api/programs/${encodeURIComponent(programId)}/templates`, {
             method: 'POST',
             credentials: 'include',
             headers: { 'Content-Type': 'application/json' },
@@ -1444,11 +1444,10 @@ async function detachTemplateAssociation(templateId, { revert, tagData } = {}) {
   let detachResult = { wasAttached: false };
   try {
     try {
-      detachResult = await fetchJson(`${API}/api/programs/${encodeURIComponent(programId)}/templates/detach`, {
-        method: 'POST',
+      detachResult = await fetchJson(`${API}/api/programs/${encodeURIComponent(programId)}/templates/${encodeURIComponent(templateId)}`, {
+        method: 'DELETE',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ template_id: templateId }),
       });
     } catch (error) {
       if (error.status === 404) {
@@ -1635,14 +1634,26 @@ async function flushPendingMetadataUpdates({ immediate = false } = {}) {
       setTemplatePanelMessage(savingMessage);
     }
     let success = false;
+    let updatedCount = 0;
     try {
-      const response = await fetchJson(`${API}/programs/${encodeURIComponent(programId)}/templates/metadata`, {
-        method: 'PATCH',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ updates: batch }),
-      });
-      const updatedCount = Number(response?.updated ?? 0);
+      for (const entry of batch) {
+        const templateId = entry?.template_id;
+        if (!templateId) continue;
+        const payload = { ...entry };
+        delete payload.template_id;
+        const response = await fetchJson(`${API}/api/programs/${encodeURIComponent(programId)}/templates/${encodeURIComponent(templateId)}`, {
+          method: 'PATCH',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (response?.template) {
+          applyTemplateMetadataToCaches(response.template);
+        }
+        if (response?.updated) {
+          updatedCount += 1;
+        }
+      }
       success = true;
       if (selectedProgramId === programId) {
         const messageToShow = updatedCount === 0 ? 'No changes were applied.' : successMessage;

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -252,7 +252,6 @@ paths:
           description: Missing `template.read` permission.
         '404':
           description: Program not found.
-  /api/programs/{programId}/templates/attach:
     post:
       summary: Attach an existing template to a program
       tags: [Programs]
@@ -268,8 +267,21 @@ paths:
                   type: string
                   description: Identifier of the template to attach.
       responses:
+        '201':
+          description: Template attached to the program.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  attached:
+                    type: boolean
+                  alreadyAttached:
+                    type: boolean
+                  template:
+                    $ref: '#/components/schemas/Template'
         '200':
-          description: Template attached or already linked.
+          description: Template was already attached to the program.
           content:
             application/json:
               schema:
@@ -289,9 +301,22 @@ paths:
           description: Missing `template.update` permission or manager not assigned.
         '404':
           description: Program or template not found.
-  /api/programs/{programId}/templates/detach:
-    post:
-      summary: Detach a template from a program
+  /api/programs/{programId}/templates/{templateId}:
+    parameters:
+      - in: path
+        name: programId
+        required: true
+        schema:
+          type: string
+        description: Identifier of the program.
+      - in: path
+        name: templateId
+        required: true
+        schema:
+          type: string
+        description: Identifier of the template assignment.
+    patch:
+      summary: Update template metadata for a program assignment
       tags: [Programs]
       requestBody:
         required: true
@@ -299,11 +324,47 @@ paths:
           application/json:
             schema:
               type: object
-              required: [template_id]
               properties:
-                template_id:
+                notes:
                   type: string
-                  description: Identifier of the template to detach.
+                due_offset_days:
+                  type: integer
+                required:
+                  type: boolean
+                visibility:
+                  type: string
+                sort_order:
+                  type: integer
+                week_number:
+                  type: integer
+                label:
+                  type: string
+                status:
+                  type: string
+                  enum: [draft, published, deprecated]
+      responses:
+        '200':
+          description: Template metadata updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  updated:
+                    type: boolean
+                  template:
+                    $ref: '#/components/schemas/Template'
+        '400':
+          description: Invalid payload.
+        '401':
+          description: Authentication required.
+        '403':
+          description: Missing `template.update` permission or manager not assigned.
+        '404':
+          description: Program or template not found.
+    delete:
+      summary: Detach a template from a program
+      tags: [Programs]
       responses:
         '200':
           description: Template detached if linked.


### PR DESCRIPTION
## Summary
- add transactional helpers and RESTful POST/PATCH/DELETE routes for program template links while reusing RBAC/auditing logic
- extend the program template link DAO to fetch/update linked templates for the new endpoints and reuse it from batch metadata updates
- switch the admin template manager UI to call the RESTful endpoints and update the OpenAPI description and API tests accordingly

## Testing
- npm test -- --runTestsByPath __tests__/templateApi.test.js
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccd79d785c832c99030de23d8a4f75