### PR TITLE
Fix audit context transaction handling

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -595,11 +595,7 @@ async function withTransaction(req, work) {
   try {
     await client.query('BEGIN');
     if (req?.user?.id) {
-      try {
-        await client.query('SET LOCAL app.current_user = $1', [req.user.id]);
-      } catch (_err) {
-        /* ignore audit context errors */
-      }
+      await client.query("select set_config('app.current_user', $1::text, true)", [req.user.id]);
     }
     const result = await work(client);
     await client.query('COMMIT');


### PR DESCRIPTION
## Summary
- update the transaction helper to call `select set_config` when applying the audit context
- allow errors while setting the context to propagate so they trigger the normal rollback path

## Testing
- `npm test -- --runTestsByPath __tests__/templates.test.ts` *(fails: ENOENT no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf527e2e8832c8778e8f4b8f2c16d