### PR TITLE
Remove instantiate banner from orientation page

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -1365,13 +1365,6 @@ useEffect(() => {
 
           </header>
 
-      {!isTrainee && needsInstantiate && (
-        <div className="card p-6">
-          <p className="mb-4">This program has no tasks yet. Load preset tasks?</p>
-          <button className="btn btn-primary" onClick={handleInstantiate}>Load Program Tasks</button>
-        </div>
-      )}
-
       {/* KPIs */}
       {!isTrainee && (
         <div className="grid md:grid-cols-4 gap-4">


### PR DESCRIPTION
## Summary
- remove the instantiate banner card from the orientation app so it never renders

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd6c3e93d0832c9e4d09cd30c434e6