### PR TITLE
Filter template library by assigned IDs

### DIFF
--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -3399,13 +3399,20 @@ async function loadProgramTemplateAssignments(options = {}) {
       fetchedLibrary = Array.isArray(fetchedLibrary) ? [...fetchedLibrary] : [];
     }
     let resolvedLibrary = Array.isArray(fetchedLibrary) ? fetchedLibrary : [];
-    if (!resolvedLibrary.length && Array.isArray(globalTemplates) && globalTemplates.length) {
-      resolvedLibrary = globalTemplates.filter(template => {
-        const id = getTemplateId(template);
-        return id && !assignedTemplateIds.has(id);
-      });
+    const filterAvailableTemplates = template => {
+      const id = getTemplateId(template);
+      return id && !assignedTemplateIds.has(id);
+    };
+    let availableTemplates = resolvedLibrary.filter(filterAvailableTemplates);
+    if (!availableTemplates.length) {
+      const fallbackTemplates = Array.isArray(globalTemplates) && globalTemplates.length
+        ? globalTemplates.filter(filterAvailableTemplates)
+        : [];
+      if (fallbackTemplates.length) {
+        availableTemplates = fallbackTemplates;
+      }
     }
-    templateLibrary = resolvedLibrary;
+    templateLibrary = availableTemplates;
     templateLibraryIndex.clear();
     templateLibrary.forEach(template => {
       const id = getTemplateId(template);


### PR DESCRIPTION
## Summary
- filter the resolved template library to remove already assigned templates
- reuse the global template fallback only when available templates are exhausted

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd6f1d2800832c8b203fed1c19a9ed