### PR TITLE
Fix template attach flush reentrancy and add regression coverage

### DIFF
--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -1204,11 +1204,21 @@ async function flushPendingTemplateAttachments({ immediate = false } = {}) {
       }
 
       if (hasSuccess && attachedStillSelected) {
-        await loadProgramTemplateAssignments({ preserveSelection: true });
+        await loadProgramTemplateAssignments({
+          preserveSelection: true,
+          skipAttachWaitFor: perform,
+        });
       }
 
       if (failureCount) {
         return false;
+      }
+      pendingAttach.clear();
+      pendingAttachState.clear();
+      pendingAttachProgramId = null;
+      if (attachSaveTimeout) {
+        clearTimeout(attachSaveTimeout);
+        attachSaveTimeout = null;
       }
       return true;
     } catch (error) {
@@ -3385,8 +3395,12 @@ function extractTemplateLibraryFromResponse(payload) {
 }
 
 async function loadProgramTemplateAssignments(options = {}) {
-  const { focusTemplateId = null, preserveSelection = false } = options;
-  if (attachInFlightPromise) {
+  const {
+    focusTemplateId = null,
+    preserveSelection = false,
+    skipAttachWaitFor = null,
+  } = options;
+  if (attachInFlightPromise && attachInFlightPromise !== skipAttachWaitFor) {
     try {
       await attachInFlightPromise;
     } catch (error) {


### PR DESCRIPTION
## Summary
- prevent `loadProgramTemplateAssignments` from awaiting the in-flight attachment flush and clear pending state after successful attaches
- extend the Tagify test harness to cover attachment flushing logic and add a regression test for consecutive flushes

## Testing
- npm test -- __tests__/program-template-manager.tagify.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cf01d0487c832ca25e34fea6f061b3