### PR TITLE
Enhance orientation calendar task modal

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -116,6 +116,37 @@ const withUserBody = (data = {}) => (
     : data
 );
 
+const ensureDisplayValue = (value, fallback = '—') => {
+  if (Array.isArray(value)) {
+    return value.length ? value : [fallback];
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+  if (typeof value === 'string' && value.trim() === '') {
+    return fallback;
+  }
+  return value;
+};
+
+const toLabelList = (labels) => {
+  const ensured = ensureDisplayValue(labels);
+  return Array.isArray(ensured) ? ensured : [ensured];
+};
+
+const toLabelString = (labels) => toLabelList(labels).join(', ');
+
+const toDisplayString = (value) => {
+  const ensured = ensureDisplayValue(value);
+  if (Array.isArray(ensured)) {
+    return ensured.join(', ');
+  }
+  return String(ensured);
+};
+
 function useFocusTrap(active, ref) {
   useEffect(() => {
     if (!active) return;
@@ -689,7 +720,12 @@ function App({ me, onSignOut }){
         title: r.label,
         notes: r.notes || '',
         completed: r.done,
-        scheduled_for: r.scheduled_for
+        scheduled_for: r.scheduled_for,
+        labels: toLabelList(r.labels),
+        week_number: typeof r.week_number === 'number' ? r.week_number : ensureDisplayValue(r.week_number),
+        journal_entry: ensureDisplayValue(r.journal_entry),
+        responsible_person: ensureDisplayValue(r.responsible_person),
+        done: typeof r.done === 'boolean' ? r.done : ensureDisplayValue(r.done)
       });
     });
     return Object.values(byWeek).sort((a,b)=> a.wk - b.wk);
@@ -808,7 +844,18 @@ useEffect(() => {
       if(t.scheduled_for){
         const key = dayjs(t.scheduled_for).format('YYYY-MM-DD');
         map[key] = map[key] || [];
-        map[key].push({ label:`W${w.wk}: ${t.title}`, done: t.completed, wi, ti, task_id: t.task_id });
+        map[key].push({
+          label:`W${w.wk}: ${t.title}`,
+          done: typeof t.done === 'boolean' ? t.done : t.completed,
+          wi,
+          ti,
+          task_id: t.task_id,
+          labels: toLabelString(t.labels),
+          week: typeof t.week_number === 'number' ? t.week_number : ensureDisplayValue(t.week_number),
+          journal_entry: ensureDisplayValue(t.journal_entry),
+          responsible_person: ensureDisplayValue(t.responsible_person),
+          scheduled_for: ensureDisplayValue(t.scheduled_for)
+        });
       }
     }));
     return map;
@@ -943,7 +990,12 @@ useEffect(() => {
           title: created.label,
           notes: created.notes || '',
           completed: created.done,
-          scheduled_for: created.scheduled_for
+          scheduled_for: created.scheduled_for,
+          labels: toLabelList(created.labels),
+          week_number: typeof created.week_number === 'number' ? created.week_number : ensureDisplayValue(created.week_number),
+          journal_entry: ensureDisplayValue(created.journal_entry),
+          responsible_person: ensureDisplayValue(created.responsible_person),
+          done: typeof created.done === 'boolean' ? created.done : ensureDisplayValue(created.done)
         };
         clone[wi].tasks = clone[wi].tasks || [];
         clone[wi].tasks.push(task);
@@ -989,7 +1041,12 @@ useEffect(() => {
           title: res.label,
           notes: res.notes || '',
           completed: res.done,
-          scheduled_for: res.scheduled_for
+          scheduled_for: res.scheduled_for,
+          labels: toLabelList(res.labels),
+          week_number: typeof res.week_number === 'number' ? res.week_number : ensureDisplayValue(res.week_number),
+          journal_entry: ensureDisplayValue(res.journal_entry),
+          responsible_person: ensureDisplayValue(res.responsible_person),
+          done: typeof res.done === 'boolean' ? res.done : ensureDisplayValue(res.done)
         };
         if (wi !== -1) {
           copy[wi].tasks.push(newTask);
@@ -1409,7 +1466,7 @@ useEffect(() => {
         <div className="grid grid-cols-7 gap-2 text-xs font-medium text-slate-500 mb-2">
           {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map(d=> <div key={d} className="text-center">{d}</div>)}
         </div>
-        <div className="grid grid-cols-7 gap-2">
+        <div id="orientationCalendar" className="grid grid-cols-7 gap-2">
           {calDays.map((d,idx)=>{
             const key = d.format('YYYY-MM-DD');
             const items = scheduledMap[key]||[];
@@ -1425,9 +1482,21 @@ useEffect(() => {
                 <div className="space-y-1">
                   {items.slice(0, expanded ? items.length : 3).map((it,i)=> (
                     <div key={i}
-                         className={`relative text-[11px] pl-2 pr-4 py-1 rounded-md border ${it.done?'bg-emerald-50 border-emerald-300':'bg-sky-50 border-sky-300'}`}
+                         className={`relative text-[11px] pl-2 pr-4 py-1 rounded-md border cursor-pointer focus-visible:ring-2 focus-visible:ring-anx-sky ${it.done?'bg-emerald-50 border-emerald-300':'bg-sky-50 border-sky-300'}`}
+                         role="button"
+                         tabIndex={0}
                          draggable={hasPerm('task.assign') && isPrivileged && !isTrainee}
-                         data-wi={it.wi} data-ti={it.ti} data-taskid={it.task_id}
+                         data-wi={it.wi}
+                         data-ti={it.ti}
+                         data-taskid={it.task_id}
+                         data-task-id={it.task_id}
+                         data-title={it.label}
+                         data-labels={toDisplayString(it.labels)}
+                         data-week={typeof it.week === 'number' || typeof it.week === 'string' ? String(it.week) : toDisplayString(it.week)}
+                         data-journal_entry={toDisplayString(it.journal_entry)}
+                         data-responsible_person={toDisplayString(it.responsible_person)}
+                         data-scheduled_for={toDisplayString(it.scheduled_for)}
+                         data-done={typeof it.done === 'boolean' ? String(it.done) : toDisplayString(it.done)}
                          onDragStart={hasPerm('task.assign') && isPrivileged && !isTrainee ? handleDragStart : undefined} onDragEnd={hasPerm('task.assign') && isPrivileged && !isTrainee ? handleDragEnd : undefined}
                          onTouchStart={hasPerm('task.assign') && isPrivileged && !isTrainee ? handleDragStart : undefined} onTouchMove={hasPerm('task.assign') && isPrivileged && !isTrainee ? handleTouchMove : undefined}
                          onTouchEnd={hasPerm('task.assign') && isPrivileged && !isTrainee ? handleTouchEnd : undefined} onTouchCancel={hasPerm('task.assign') && isPrivileged && !isTrainee ? handleTouchEnd : undefined}>
@@ -1849,6 +1918,306 @@ return <App me={me} onSignOut={async () => { const res = await apiLogout(); if(!
 }
 
 ReactDOM.createRoot(document.getElementById('root')).render(<Root/>);
+</script>
+
+<style>
+  #orientationTaskModal {
+    border: none;
+    border-radius: 1rem;
+    padding: 0;
+    width: min(560px, 90vw);
+    max-width: 560px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
+  }
+  #orientationTaskModal::backdrop {
+    background: rgba(15, 23, 42, 0.45);
+  }
+  #orientationTaskModal form {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+  }
+  #orientationTaskModal .orientation-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid #e2e8f0;
+  }
+  #orientationTaskModal .orientation-modal__body {
+    padding: 1.25rem;
+  }
+  #orientationTaskModal .orientation-modal__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  #orientationTaskModal .orientation-modal__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  #orientationTaskModal .orientation-modal__field.full-span {
+    grid-column: 1 / -1;
+  }
+  #orientationTaskModal .orientation-modal__label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #94a3b8;
+    font-weight: 600;
+  }
+  #orientationTaskModal .orientation-modal__value {
+    font-size: 0.95rem;
+    color: #1f2937;
+    word-break: break-word;
+  }
+  #orientationTaskModal .orientation-modal__value.muted {
+    color: #64748b;
+  }
+  #orientationTaskModal textarea {
+    width: 100%;
+    min-height: 140px;
+    resize: vertical;
+    border-radius: 0.75rem;
+    border: 1px solid #cbd5f5;
+    padding: 0.75rem;
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+  #orientationTaskModal .orientation-modal__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-top: 1px solid #e2e8f0;
+  }
+  #orientationTaskModal button.btn-ghost {
+    color: #475569;
+  }
+  @media (max-width: 640px) {
+    #orientationTaskModal .orientation-modal__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+
+<dialog id="orientationTaskModal" aria-labelledby="orientationTaskModalTitle" aria-modal="true">
+  <form id="orientationTaskForm" method="dialog">
+    <div class="orientation-modal__header">
+      <div>
+        <h2 id="orientationTaskModalTitle" class="text-lg font-semibold text-slate-800">Task Details</h2>
+        <p class="text-sm text-slate-500" data-modal-field="subtitle">Review and update the trainee journal entry.</p>
+      </div>
+      <button type="button" class="btn btn-ghost text-sm" data-close-modal>Close</button>
+    </div>
+    <div class="orientation-modal__body">
+      <div class="orientation-modal__grid">
+        <div class="orientation-modal__field full-span">
+          <span class="orientation-modal__label">Task</span>
+          <span class="orientation-modal__value" data-modal-field="title">—</span>
+        </div>
+        <div class="orientation-modal__field">
+          <span class="orientation-modal__label">Week</span>
+          <span class="orientation-modal__value muted" data-modal-field="week">—</span>
+        </div>
+        <div class="orientation-modal__field">
+          <span class="orientation-modal__label">Scheduled</span>
+          <span class="orientation-modal__value muted" data-modal-field="scheduled">—</span>
+        </div>
+        <div class="orientation-modal__field">
+          <span class="orientation-modal__label">Responsible</span>
+          <span class="orientation-modal__value muted" data-modal-field="responsible">—</span>
+        </div>
+        <div class="orientation-modal__field">
+          <span class="orientation-modal__label">Status</span>
+          <span class="orientation-modal__value muted" data-modal-field="done">—</span>
+        </div>
+        <div class="orientation-modal__field full-span">
+          <span class="orientation-modal__label">Labels</span>
+          <span class="orientation-modal__value muted" data-modal-field="labels">—</span>
+        </div>
+        <div class="orientation-modal__field full-span">
+          <span class="orientation-modal__label">Journal Entry</span>
+          <textarea name="journal_entry" id="orientationTaskJournal" placeholder="Add a journal entry…"></textarea>
+        </div>
+      </div>
+    </div>
+    <div class="orientation-modal__footer">
+      <button type="button" class="btn btn-ghost" data-close-modal>Cancel</button>
+      <button type="submit" class="btn btn-primary" data-save-modal>Save</button>
+    </div>
+  </form>
+</dialog>
+
+<script>
+  (function(){
+    const calendar = document.getElementById('orientationCalendar');
+    const modal = document.getElementById('orientationTaskModal');
+    if (!calendar || !modal) return;
+
+    const form = document.getElementById('orientationTaskForm');
+    const journalField = document.getElementById('orientationTaskJournal');
+    const fieldMap = {
+      title: modal.querySelector('[data-modal-field="title"]'),
+      week: modal.querySelector('[data-modal-field="week"]'),
+      scheduled: modal.querySelector('[data-modal-field="scheduled"]'),
+      responsible: modal.querySelector('[data-modal-field="responsible"]'),
+      done: modal.querySelector('[data-modal-field="done"]'),
+      labels: modal.querySelector('[data-modal-field="labels"]')
+    };
+
+    const closeButtons = modal.querySelectorAll('[data-close-modal]');
+    let activeTrigger = null;
+    let lastFocusedElement = null;
+    const focusableSelector = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+    let focusTrapListener = null;
+
+    const toDisplay = (value) => {
+      if (value === undefined || value === null) return '—';
+      const str = typeof value === 'string' ? value : String(value);
+      const trimmed = str.trim();
+      if (trimmed === '' || trimmed.toLowerCase() === 'undefined' || trimmed.toLowerCase() === 'null') {
+        return '—';
+      }
+      return trimmed;
+    };
+
+    const toStatus = (value) => {
+      const normalized = toDisplay(value).toLowerCase();
+      if (normalized === 'true') return 'Complete';
+      if (normalized === 'false') return 'Not complete';
+      return toDisplay(value);
+    };
+
+    const trapFocus = () => {
+      if (focusTrapListener) return;
+      focusTrapListener = (event) => {
+        if (event.key !== 'Tab') return;
+        const focusable = Array.from(modal.querySelectorAll(focusableSelector)).filter(el => !el.hasAttribute('disabled'));
+        if (!focusable.length) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey) {
+          if (document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      };
+      document.addEventListener('keydown', focusTrapListener);
+    };
+
+    const releaseFocusTrap = () => {
+      if (!focusTrapListener) return;
+      document.removeEventListener('keydown', focusTrapListener);
+      focusTrapListener = null;
+    };
+
+    const openModal = (trigger) => {
+      activeTrigger = trigger;
+      lastFocusedElement = document.activeElement;
+      const { dataset } = trigger;
+      modal.dataset.taskId = dataset.taskId || '';
+      if (fieldMap.title) fieldMap.title.textContent = toDisplay(dataset.title || trigger.textContent || '—');
+      if (fieldMap.week) fieldMap.week.textContent = toDisplay(dataset.week);
+      if (fieldMap.scheduled) fieldMap.scheduled.textContent = toDisplay(dataset.scheduled_for);
+      if (fieldMap.responsible) fieldMap.responsible.textContent = toDisplay(dataset.responsible_person);
+      if (fieldMap.done) fieldMap.done.textContent = toStatus(dataset.done);
+      if (fieldMap.labels) fieldMap.labels.textContent = toDisplay(dataset.labels);
+
+      const journalValue = dataset.journal_entry && dataset.journal_entry !== '—' ? dataset.journal_entry : '';
+      journalField.value = journalValue;
+      modal.showModal();
+      trapFocus();
+      window.requestAnimationFrame(() => {
+        journalField.focus();
+        journalField.setSelectionRange(journalField.value.length, journalField.value.length);
+      });
+    };
+
+    const closeModal = (restoreFocus = true) => {
+      releaseFocusTrap();
+      if (modal.open) {
+        modal.close();
+      }
+      if (restoreFocus && activeTrigger) {
+        activeTrigger.focus();
+      } else if (restoreFocus && lastFocusedElement) {
+        lastFocusedElement.focus();
+      }
+      activeTrigger = null;
+      lastFocusedElement = null;
+    };
+
+    const handleSave = () => {
+      if (!activeTrigger) {
+        closeModal();
+        return;
+      }
+      const taskId = activeTrigger.dataset.taskId;
+      const entryValue = journalField.value;
+      const datasetValue = entryValue.trim() === '' ? '—' : entryValue;
+      activeTrigger.dataset.journal_entry = datasetValue;
+      window.dispatchEvent(new CustomEvent('orientation:journal:update', {
+        detail: { taskId, journal_entry: entryValue }
+      }));
+      closeModal();
+    };
+
+    calendar.addEventListener('click', (event) => {
+      const trigger = event.target.closest('[data-task-id]');
+      if (!trigger || trigger.hasAttribute('disabled')) return;
+      if (!calendar.contains(trigger)) return;
+      event.preventDefault();
+      openModal(trigger);
+    });
+
+    calendar.addEventListener('keydown', (event) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      const trigger = event.target.closest('[data-task-id]');
+      if (!trigger || trigger.hasAttribute('disabled')) return;
+      if (!calendar.contains(trigger)) return;
+      event.preventDefault();
+      openModal(trigger);
+    });
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      handleSave();
+    });
+
+    form.addEventListener('keydown', (event) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+        event.preventDefault();
+        handleSave();
+      }
+    });
+
+    modal.addEventListener('cancel', (event) => {
+      event.preventDefault();
+      closeModal();
+    });
+
+    modal.addEventListener('click', (event) => {
+      const rect = modal.getBoundingClientRect();
+      const { clientX, clientY } = event;
+      const withinDialog = clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom;
+      if (!withinDialog) {
+        closeModal();
+      }
+    });
+
+    closeButtons.forEach((btn) => {
+      btn.addEventListener('click', (event) => {
+        event.preventDefault();
+        closeModal();
+      });
+    });
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- retain additional orientation task metadata and expose it for the visual calendar
- render scheduled tasks as accessible buttons with detailed data attributes and a shared modal
- add modal styling and scripted interactions to review and edit journal entries

## Testing
- npm test *(fails: existing programRoutes patch tests error because programTemplateLinksDao.updateLink/getTemplateForProgram are not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68d018706f7c832c9f9b7d2351c9bcba