### PR TITLE
Expose archived templates in UI

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -21,6 +21,7 @@ export interface Template {
   category: string;
   updatedAt?: string;
   status?: 'draft' | 'published' | 'deprecated';
+  deletedAt?: string | null;
 }
 
 type UserListResponse = { data: User[]; meta: { total: number; page: number } };
@@ -260,6 +261,15 @@ const normalizeTemplate = (raw: any): Template => {
   if (normalizedStatus) {
     template.status = normalizedStatus;
   }
+  const deletedCandidate = raw.deletedAt ?? raw.deleted_at;
+  if (deletedCandidate !== undefined) {
+    if (deletedCandidate === null) {
+      template.deletedAt = null;
+    } else {
+      const parsedDeleted = toDateString(deletedCandidate);
+      template.deletedAt = parsedDeleted || String(deletedCandidate);
+    }
+  }
   return template;
 };
 
@@ -292,7 +302,7 @@ const buildProgramWritePayload = (payload: Partial<Program>): Record<string, unk
 };
 
 const buildTemplateWritePayload = (payload: Partial<Template>): Record<string, unknown> => {
-  const { id: _id, programId: _programId, updatedAt: _updatedAt, ...rest } = payload;
+  const { id: _id, programId: _programId, updatedAt: _updatedAt, deletedAt: _deletedAt, ...rest } = payload;
   const body: Record<string, unknown> = { ...rest };
   if (payload.name && !body.label) {
     body.label = payload.name;


### PR DESCRIPTION
## Summary
- surface `deleted_at` in template normalization and write payload handling
- fetch archived templates on the Programs landing page, split active vs archived, and add restore/refresh actions
- extend program template DAO utilities and add coverage to ensure restoring archived templates returns them to listings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d018b81ed8832c856c507fa2d17bae