### PR TITLE
Defer orientation modal setup until elements exist

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -2052,11 +2052,16 @@ ReactDOM.createRoot(document.getElementById('root')).render(<Root/>);
 
 <script>
   (function(){
-    const calendar = document.getElementById('orientationCalendar');
-    const modal = document.getElementById('orientationTaskModal');
-    if (!calendar || !modal) return;
+    const scheduleRetry = (callback) => {
+      if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(callback);
+      } else {
+        window.setTimeout(callback, 16);
+      }
+    };
 
-    const form = document.getElementById('orientationTaskForm');
+    const setupModal = (calendar, modal) => {
+      const form = document.getElementById('orientationTaskForm');
     const journalField = document.getElementById('orientationTaskJournal');
     const fieldMap = {
       title: modal.querySelector('[data-modal-field="title"]'),
@@ -2211,12 +2216,25 @@ ReactDOM.createRoot(document.getElementById('root')).render(<Root/>);
       }
     });
 
-    closeButtons.forEach((btn) => {
-      btn.addEventListener('click', (event) => {
-        event.preventDefault();
-        closeModal();
+      closeButtons.forEach((btn) => {
+        btn.addEventListener('click', (event) => {
+          event.preventDefault();
+          closeModal();
+        });
       });
-    });
+    };
+
+    const init = () => {
+      const calendar = document.getElementById('orientationCalendar');
+      const modal = document.getElementById('orientationTaskModal');
+      if (!calendar || !modal) {
+        scheduleRetry(init);
+        return;
+      }
+      setupModal(calendar, modal);
+    };
+
+    init();
   })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- wait to initialize the orientation task modal until both the calendar and modal elements are present
- keep the existing event handling logic intact once the elements are located

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d01e6cffd8832cbb3f4e1a1b0b4755