### PR TITLE
Allow managing new task metadata fields

### DIFF
--- a/__tests__/programRoutes.test.js
+++ b/__tests__/programRoutes.test.js
@@ -114,10 +114,13 @@ describe('program routes', () => {
         trainee text,
         label text not null,
         scheduled_for date,
+        scheduled_time time,
         done boolean,
         program_id text,
         week_number int,
         notes text,
+        journal_entry text,
+        responsible_person text,
         deleted boolean default false
       );
       insert into public.roles(role_key) values ('admin'),('manager'),('viewer'),('trainee'),('auditor');


### PR DESCRIPTION
## Summary
- add support for updating task journal entries, responsible person, and a time alias in the tasks API
- include the new task metadata columns when instantiating programs and creating tasks
- extend the pg-mem schemas and authorization tests to exercise the new fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0475175f4832caf6752404977bd79