### PR TITLE
Add scheduled_time column to orientation_tasks

### DIFF
--- a/migrations/011_add_scheduled_time_to_orientation_tasks.down.sql
+++ b/migrations/011_add_scheduled_time_to_orientation_tasks.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE public.orientation_tasks
+  DROP COLUMN IF EXISTS scheduled_time;
+
+COMMIT;

--- a/migrations/011_add_scheduled_time_to_orientation_tasks.sql
+++ b/migrations/011_add_scheduled_time_to_orientation_tasks.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE public.orientation_tasks
+  ADD COLUMN scheduled_time time;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a forward SQL migration that introduces the nullable scheduled_time column on public.orientation_tasks
- add a matching down migration that removes the scheduled_time column if rolled back

## Testing
- npm test -- --runTestsByPath __tests__/taskRoutesAuth.test.js
- npm test -- --runTestsByPath __tests__/programRoutes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d04f5f2038832cb00ef60228bad8f9