### PR TITLE
Add pagination controls to program manager

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -371,6 +371,23 @@
         <div id="programSelectionSummary" class="text-xs text-slate-500 md:text-right">No programs selected.</div>
       </div>
 
+      <div class="flex items-center justify-between gap-3 flex-wrap text-xs text-slate-500">
+        <label class="flex items-center gap-2 font-semibold uppercase tracking-wide">
+          <span>Rows per page</span>
+          <select id="programPageSize" class="input w-24 text-sm font-medium normal-case">
+            <option value="10" selected>10</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+            <option value="all">All</option>
+          </select>
+        </label>
+        <div id="pager" class="flex items-center gap-2">
+          <button type="button" id="programPagerPrev" class="btn btn-outline text-xs">Prev</button>
+          <span id="programPagerLabel" class="text-xs">Page 0 of 0</span>
+          <button type="button" id="programPagerNext" class="btn btn-outline text-xs">Next</button>
+        </div>
+      </div>
+
       <div class="panel-section overflow-hidden">
         <div class="overflow-x-auto">
           <table class="table min-w-full" id="programTable">


### PR DESCRIPTION
## Summary
- add a page-size selector and pager controls to the Programs table toolbar
- introduce pagination helpers and state so filters, sorting, and pagination are applied before rendering
- update event handlers to keep selections and pager status in sync with the current page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d04deceb3c832ca6ccc53aee3fa601