### PR TITLE
Add hide archived filter for program manager

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -357,6 +357,10 @@
           <p class="text-sm text-slate-500">Select programs to publish, deprecate, archive, or restore.</p>
         </div>
         <div class="flex items-center gap-2 flex-wrap justify-end">
+          <label class="flex items-center gap-2 text-sm">
+            <input type="checkbox" id="hideArchived" class="rounded border-slate-300">
+            Hide archived
+          </label>
           <button id="btnNewProgram" class="btn btn-primary text-sm">New Program</button>
           <button id="btnEditProgram" class="btn btn-outline text-sm" disabled>Edit Program</button>
           <button id="btnRefreshPrograms" class="btn btn-outline text-sm">Refresh</button>


### PR DESCRIPTION
## Summary
- add a Hide archived checkbox to the Programs toolbar
- filter archived programs before sorting/pagination and mark rows with data-archived metadata
- keep selections/export logic in sync with the filtered set when hiding archived programs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d053c4c450832c80a471ada7939fb5