### PR TITLE
Add CSV export for programs table

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -363,6 +363,7 @@
           </label>
           <button id="btnNewProgram" class="btn btn-primary text-sm">New Program</button>
           <button id="btnEditProgram" class="btn btn-outline text-sm" disabled>Edit Program</button>
+          <button id="exportCsv" class="btn btn-outline text-sm">Export CSV</button>
           <button id="btnRefreshPrograms" class="btn btn-outline text-sm">Refresh</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add an Export CSV button to the program manager toolbar
- generate CSV content from the filtered and sorted program list using plain-text cell values
- hook the export button up to download the CSV via a blob URL

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d05b2817c4832ca32cbfed4f51b2c8