### PR TITLE
Remove archive program action from program manager page

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -354,7 +354,7 @@
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div>
           <h2 class="text-xl font-semibold">Programs</h2>
-          <p class="text-sm text-slate-500">Select programs to publish, deprecate, archive, or restore.</p>
+          <p class="text-sm text-slate-500">Select programs to publish, deprecate, or restore.</p>
         </div>
         <div class="flex items-center gap-2 flex-wrap justify-end">
           <label class="flex items-center gap-2 text-sm">
@@ -466,7 +466,6 @@
         <div class="flex flex-wrap gap-2" id="programActions">
           <button class="btn btn-primary" data-program-action="publish">Publish</button>
           <button class="btn btn-outline" data-program-action="deprecate">Deprecate</button>
-          <button class="btn btn-outline" data-program-action="archive">Archive</button>
           <button class="btn btn-outline" data-program-action="restore">Restore</button>
         </div>
         <div id="programActionHint" class="text-xs text-slate-500">Select one or more programs to enable lifecycle actions.</div>

--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -3119,8 +3119,9 @@ function updateProgramActionsState(displayedPrograms) {
       return;
     }
     if (ADMIN_ONLY_PROGRAM_ACTIONS.has(action) && !IS_ADMIN) {
+      const actionLabel = action ? `${action.charAt(0).toUpperCase()}${action.slice(1)}` : 'perform this';
       btn.disabled = true;
-      btn.title = 'Only admins can archive or restore programs.';
+      btn.title = `Only admins can ${actionLabel.toLowerCase()} programs.`;
       return;
     }
     btn.disabled = !hasSelection;


### PR DESCRIPTION
## Summary
- remove the archive action button from the program & template manager view and update helper text
- adjust program action enable/disable messaging to work without the archive button while still respecting admin-only actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d05cd602b4832cbfb33cec64a72194