### PR TITLE
Sort scheduled calendar tasks chronologically

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -948,6 +948,21 @@ useEffect(() => {
         });
       }
     }));
+    Object.keys(map).forEach((key) => {
+      map[key].sort((a, b) => {
+        const aTime = a.scheduled_time || '';
+        const bTime = b.scheduled_time || '';
+        if (aTime && bTime) {
+          if (aTime < bTime) return -1;
+          if (aTime > bTime) return 1;
+        } else if (aTime && !bTime) {
+          return -1;
+        } else if (!aTime && bTime) {
+          return 1;
+        }
+        return a.label.localeCompare(b.label);
+      });
+    });
     return map;
   }, [weeks]);
 


### PR DESCRIPTION
## Summary
- sort each day's scheduled task list in `public/orientation_index.html`
- ensure tasks with normalized times appear first in ascending order and fall back to label sorting for stability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d065abe090832ca63bdf3397b8a12a