### PR TITLE
Add restore action for archived templates

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -568,6 +568,7 @@
                         </span>
                       </button>
                     </th>
+                    <th class="text-right">Actions</th>
                   </tr>
                 </thead>
                 <tbody id="templateTableBody" class="bg-white text-sm"></tbody>


### PR DESCRIPTION
## Summary
- add an actions column with a restore control to the admin template table
- wire the restore button to the template restore API, refresh cached data, and show toast feedback
- add a lightweight toast utility for success and error messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d07e85ebb8832c9ac94f6e3fb25c84