### PR TITLE
Add organization metadata to program templates

### DIFF
--- a/__tests__/programRoutes.test.js
+++ b/__tests__/programRoutes.test.js
@@ -63,12 +63,15 @@ describe('program routes', () => {
         week_number int,
         label text not null,
         notes text,
+        organization text,
+        sub_unit text,
         due_offset_days int,
         required boolean,
         visibility text,
         sort_order int,
         status text default 'draft',
-        deleted_at timestamp
+        deleted_at timestamp,
+        external_link text
       );
       create table public.program_template_links (
         id uuid primary key default gen_random_uuid(),

--- a/__tests__/templateApi.test.js
+++ b/__tests__/templateApi.test.js
@@ -64,12 +64,15 @@ describe('template api', () => {
         week_number int,
         label text not null,
         notes text,
+        organization text,
+        sub_unit text,
         due_offset_days int,
         required boolean,
         visibility text,
         sort_order int,
         status text default 'draft',
-        deleted_at timestamp
+        deleted_at timestamp,
+        external_link text
       );
       create table public.program_template_links (
         id uuid primary key default gen_random_uuid(),

--- a/migrations/012_add_organization_fields_to_templates.down.sql
+++ b/migrations/012_add_organization_fields_to_templates.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE public.program_task_templates
+  DROP COLUMN IF EXISTS external_link,
+  DROP COLUMN IF EXISTS sub_unit,
+  DROP COLUMN IF EXISTS organization;
+
+COMMIT;

--- a/migrations/012_add_organization_fields_to_templates.sql
+++ b/migrations/012_add_organization_fields_to_templates.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE public.program_task_templates
+  ADD COLUMN IF NOT EXISTS organization text,
+  ADD COLUMN IF NOT EXISTS sub_unit text,
+  ADD COLUMN IF NOT EXISTS external_link text;
+
+COMMIT;

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -748,12 +748,32 @@ apiRouter.post('/templates', ensurePerm('template.create'), async (req, res) => 
       }
       status = normalizedStatus;
     }
+    const organizationValue = toNullableString(body.organization ?? body.org ?? null);
+    let subUnitRaw = null;
+    if (Object.prototype.hasOwnProperty.call(body, 'sub_unit')) {
+      subUnitRaw = body.sub_unit;
+    } else if (Object.prototype.hasOwnProperty.call(body, 'subUnit')) {
+      subUnitRaw = body.subUnit;
+    }
+    const subUnitValue = toNullableString(subUnitRaw);
+    let externalLinkRaw = null;
+    if (Object.prototype.hasOwnProperty.call(body, 'external_link')) {
+      externalLinkRaw = body.external_link;
+    } else if (Object.prototype.hasOwnProperty.call(body, 'externalLink')) {
+      externalLinkRaw = body.externalLink;
+    } else if (Object.prototype.hasOwnProperty.call(body, 'hyperlink')) {
+      externalLinkRaw = body.hyperlink;
+    }
+    const externalLinkValue = toNullableString(externalLinkRaw);
     const template = await templatesDao.create({
       week_number: weekNumber,
       label: rawLabel,
       notes: coerceNotes(body.notes),
       sort_order: sortOrder,
       status,
+      organization: organizationValue,
+      sub_unit: subUnitValue,
+      external_link: externalLinkValue,
     });
     res.status(201).json(template);
   } catch (err) {
@@ -812,12 +832,29 @@ apiRouter.patch('/templates/:templateId', ensurePerm('template.update'), async (
     if (Object.prototype.hasOwnProperty.call(body, 'notes')) {
       patch.notes = coerceNotes(body.notes);
     }
+    if (Object.prototype.hasOwnProperty.call(body, 'organization')) {
+      patch.organization = toNullableString(body.organization);
+    } else if (Object.prototype.hasOwnProperty.call(body, 'org')) {
+      patch.organization = toNullableString(body.org);
+    }
+    if (Object.prototype.hasOwnProperty.call(body, 'sub_unit')) {
+      patch.sub_unit = toNullableString(body.sub_unit);
+    } else if (Object.prototype.hasOwnProperty.call(body, 'subUnit')) {
+      patch.sub_unit = toNullableString(body.subUnit);
+    }
     if (Object.prototype.hasOwnProperty.call(body, 'sort_order')) {
       const sortOrder = parseOptionalInteger(body.sort_order);
       if (sortOrder === undefined) {
         return res.status(400).json({ error: 'invalid_sort_order' });
       }
       patch.sort_order = sortOrder;
+    }
+    if (Object.prototype.hasOwnProperty.call(body, 'external_link')) {
+      patch.external_link = toNullableString(body.external_link);
+    } else if (Object.prototype.hasOwnProperty.call(body, 'externalLink')) {
+      patch.external_link = toNullableString(body.externalLink);
+    } else if (Object.prototype.hasOwnProperty.call(body, 'hyperlink')) {
+      patch.external_link = toNullableString(body.hyperlink);
     }
     if (Object.prototype.hasOwnProperty.call(body, 'status')) {
       const normalizedStatus = normalizeTemplateStatus(String(body.status));

--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -720,6 +720,16 @@
             <label for="templateFormLabel" class="label-text mb-1">Label</label>
             <input id="templateFormLabel" name="label" class="input" placeholder="Template label" required>
           </div>
+          <div class="grid gap-3 md:grid-cols-2">
+            <label class="space-y-1">
+              <span class="label-text">Organization</span>
+              <input id="templateFormOrganization" name="organization" class="input" placeholder="e.g. Onboarding Ops">
+            </label>
+            <label class="space-y-1">
+              <span class="label-text">Sub-unit</span>
+              <input id="templateFormSubUnit" name="sub_unit" class="input" placeholder="e.g. New Hire Experience">
+            </label>
+          </div>
           <div>
             <label for="templateFormNotes" class="label-text mb-1">Notes</label>
             <textarea id="templateFormNotes" name="notes" class="textarea" placeholder="Add context or guidance for collaborators..."></textarea>


### PR DESCRIPTION
## Summary
- add organization and sub-unit fields to the admin template modal and payload
- persist organization, sub-unit, and external link attributes via the template DAO and API
- add a migration for the new columns and update pg-mem test schemas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d084985794832cb715efdf3e94e4cd