### PR TITLE
Include external link in program template listings

### DIFF
--- a/__tests__/programRoutes.test.js
+++ b/__tests__/programRoutes.test.js
@@ -652,6 +652,38 @@ test('soft deleted template can be restored', async () => {
   expect(String(res.body[0].template_id)).toBe(String(tmplId));
 });
 
+test('api program template listing includes external link', async () => {
+  const userId = crypto.randomUUID();
+  const hash = await bcrypt.hash('passpass', 1);
+  await pool.query('insert into public.users(id, username, password_hash, provider) values ($1,$2,$3,$4)', [userId, 'user4b-api', hash, 'local']);
+  await pool.query('insert into public.user_roles(user_id, role_id) select $1, role_id from public.roles where role_key=$2', [userId, 'admin']);
+
+  const agent = request.agent(app);
+  await agent.post('/auth/local/login').send({ username: 'user4b-api', password: 'passpass' }).expect(200);
+
+  const progId = 'prog4b-api';
+  await pool.query('insert into public.programs(program_id, title, created_by) values ($1,$2,$3)', [progId, 'title', userId]);
+  const tmplId = nextTemplateId();
+  const hyperlink = 'https://example.com/resource';
+  await pool.query('insert into public.program_task_templates(template_id, week_number, label, external_link) values ($1,$2,$3,$4)', [
+    tmplId,
+    1,
+    'tmp',
+    hyperlink,
+  ]);
+  await pool.query('insert into public.program_template_links(id, template_id, program_id) values ($1,$2,$3)', [
+    crypto.randomUUID(),
+    tmplId,
+    progId,
+  ]);
+
+  const res = await agent.get(`/api/programs/${progId}/templates`).expect(200);
+  expect(Array.isArray(res.body?.data)).toBe(true);
+  expect(res.body.data).toHaveLength(1);
+  expect(res.body.data[0].external_link).toBe(hyperlink);
+  expect(res.body.data[0].hyperlink).toBe(hyperlink);
+});
+
 test('instantiate skips soft deleted templates', async () => {
   const userId = crypto.randomUUID();
   const hash = await bcrypt.hash('passpass', 1);

--- a/db/programTemplateLinks.js
+++ b/db/programTemplateLinks.js
@@ -114,6 +114,7 @@ function createProgramTemplateLinksDao(pool) {
              t.label,
              t.status,
              t.deleted_at,
+             t.external_link as external_link,
              l.program_id,
              l.id as link_id,
              l.created_at,
@@ -238,6 +239,7 @@ function createProgramTemplateLinksDao(pool) {
              t.sort_order,
              t.status,
              t.deleted_at,
+             t.external_link as external_link,
              l.program_id,
              l.created_at
         from public.program_task_templates t
@@ -263,6 +265,7 @@ function createProgramTemplateLinksDao(pool) {
              t.label,
              t.status,
              t.deleted_at,
+             t.external_link as external_link,
              l.program_id,
              l.id as link_id,
              l.created_at,


### PR DESCRIPTION
## Summary
- ensure DAO queries joining program_task_templates select and expose external_link
- add regression coverage verifying the API returns template hyperlinks when listing program templates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a5fd45ac832ca1654f49df74c5bd