### PR TITLE
Add combined orientation calendar view across programs

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -232,6 +232,93 @@ const deriveTimeFromTask = (task = {}) => (
   normalizeTimeValue(task.scheduled_time) || normalizeTimeValue(task.scheduled_for)
 );
 
+const HEX_COLOR_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+const clamp01 = (value) => Math.max(0, Math.min(1, value));
+
+const rgbToHsl = (r, g, b) => {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rn:
+        h = (gn - bn) / d + (gn < bn ? 6 : 0);
+        break;
+      case gn:
+        h = (bn - rn) / d + 2;
+        break;
+      default:
+        h = (rn - gn) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+  return {
+    h: Math.round((h % 1) * 360),
+    s: Math.round(clamp01(s) * 100),
+    l: Math.round(clamp01(l) * 100)
+  };
+};
+
+const parseColorToHsl = (color) => {
+  if (!color || typeof color !== 'string') return null;
+  const trimmed = color.trim();
+  if (HEX_COLOR_PATTERN.test(trimmed)) {
+    const hex = trimmed.slice(1);
+    const normalized = hex.length === 3
+      ? hex.split('').map((ch) => parseInt(ch + ch, 16))
+      : [
+          parseInt(hex.slice(0, 2), 16),
+          parseInt(hex.slice(2, 4), 16),
+          parseInt(hex.slice(4, 6), 16)
+        ];
+    if (normalized.some((v) => Number.isNaN(v))) return null;
+    return rgbToHsl(normalized[0], normalized[1], normalized[2]);
+  }
+  const hslMatch = trimmed.match(/^hsl\s*\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)%\s*,\s*(\d+(?:\.\d+)?)%\s*\)$/i);
+  if (hslMatch) {
+    return {
+      h: Math.round(Number(hslMatch[1]) % 360),
+      s: Math.round(clamp01(Number(hslMatch[2]) / 100) * 100),
+      l: Math.round(clamp01(Number(hslMatch[3]) / 100) * 100)
+    };
+  }
+  return null;
+};
+
+const buildPaletteForProgram = (programId, colorInput) => {
+  const baseId = String(programId || 'program');
+  let hsl = parseColorToHsl(colorInput);
+  if (!hsl) {
+    let hash = 0;
+    for (let i = 0; i < baseId.length; i += 1) {
+      hash = (hash * 31 + baseId.charCodeAt(i)) >>> 0;
+    }
+    hsl = {
+      h: hash % 360,
+      s: 65,
+      l: 52
+    };
+  }
+  const borderLightness = Math.max(20, Math.min(60, hsl.l - 8));
+  const backgroundLightness = Math.max(borderLightness + 28, Math.min(95, hsl.l + 34));
+  const primarySaturation = Math.max(40, Math.min(80, hsl.s));
+  const backgroundSaturation = Math.max(25, Math.min(60, primarySaturation - 15));
+  return {
+    border: `hsl(${hsl.h}, ${primarySaturation}%, ${borderLightness}%)`,
+    background: `hsl(${hsl.h}, ${backgroundSaturation}%, ${backgroundLightness}%)`,
+    dot: `hsl(${hsl.h}, ${primarySaturation}%, ${Math.max(25, Math.min(65, hsl.l))}%)`
+  };
+};
+
 function useFocusTrap(active, ref) {
   useEffect(() => {
     if (!active) return;
@@ -635,6 +722,7 @@ function App({ me, onSignOut }){
   const [startDate, setStartDate] = useState(dayjs().format('YYYY-MM-DD'));
   const [numWeeks, setNumWeeks] = useState(6);
   const [weeks, setWeeks] = useState([]);
+  const [activeProgramId, setActiveProgramId] = useState(QS_PROGRAM_ID);
   const [deletedTasks, setDeletedTasks] = useState([]);
   const [assignPicker, setAssignPicker] = useState(null); // {date}
   const [dragBadge, setDragBadge] = useState(null);       // {wi,ti,task_id}
@@ -642,6 +730,11 @@ function App({ me, onSignOut }){
   const [needsInstantiate, setNeedsInstantiate] = useState(false);
   const [programs, setPrograms] = useState([]);
   const [userPrograms, setUserPrograms] = useState([]);
+  const [calendarMode, setCalendarMode] = useState('single');
+  const [calendarSelectValue, setCalendarSelectValue] = useState(() => (QS_PROGRAM_ID ? String(QS_PROGRAM_ID) : '__current__'));
+  const [allCalendarEvents, setAllCalendarEvents] = useState([]);
+  const [allCalendarPrograms, setAllCalendarPrograms] = useState([]);
+  const [programVisibility, setProgramVisibility] = useState({});
   const [programModal, setProgramModal] = useState({ show:false, program:null });
   const [panelOpen, setPanelOpen] = useLocalStorageState('anx_panel_open', false);
   const [panelWidth, setPanelWidth] = useLocalStorageState('anx_panel_width_px', 260);
@@ -652,11 +745,47 @@ function App({ me, onSignOut }){
   const touchHover = useRef(null);
   const panelRef = useRef(null);
   const triggerRef = useRef(null);
+  const calendarCacheRef = useRef(new Map());
+  const programColorCache = useRef(new Map());
+  const getProgramPalette = useCallback((programId, colorInput) => {
+    const key = `${String(programId || '')}::${String(colorInput || '')}`;
+    if (programColorCache.current.has(key)) {
+      return programColorCache.current.get(key);
+    }
+    const palette = buildPaletteForProgram(programId, colorInput);
+    programColorCache.current.set(key, palette);
+    return palette;
+  }, []);
   const filteredPrograms = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
     if (!term) return userPrograms;
     return userPrograms.filter(p => (p.title || '').toLowerCase().includes(term));
   }, [searchTerm, userPrograms]);
+  const programInfoMap = useMemo(() => {
+    const map = new Map();
+    const extract = (program = {}) => {
+      const id = program.program_id || program.id || program.uuid;
+      if (!id) return null;
+      const normalizedId = String(id);
+      if (!normalizedId) return null;
+      const name = program.title || program.name || program.program_name || program.full_name || 'Untitled Program';
+      const color = program.color || program.brand_color || program.accent_color || program.hex_color || program.primary_color || null;
+      return { id: normalizedId, name, color };
+    };
+    programs.forEach((program) => {
+      const info = extract(program);
+      if (info) {
+        map.set(info.id, info);
+      }
+    });
+    userPrograms.forEach((program) => {
+      const info = extract({ ...program, program_id: program.program_id });
+      if (info && !map.has(info.id)) {
+        map.set(info.id, info);
+      }
+    });
+    return map;
+  }, [programs, userPrograms]);
   const perms = useMemo(() => new Set(me?.perms || []), [me]);
   const hasPerm = (p) => perms.has(p);
   const isTrainee = (me?.roles || []).includes('trainee');
@@ -696,6 +825,7 @@ function App({ me, onSignOut }){
     try {
       const prefs = await apiGetPrefs(); // NOTE: server /prefs returns current user's prefs by default
       QS_PROGRAM_ID = prefs.program_id || null;
+      setActiveProgramId(QS_PROGRAM_ID);
       if (QS_PROGRAM_ID) {
         const count = await reloadTasks();
         setNeedsInstantiate(count === 0);
@@ -703,6 +833,7 @@ function App({ me, onSignOut }){
         setWeeks([]);
         setDeletedTasks([]);
         setNeedsInstantiate(false);
+        setActiveProgramId(null);
       }
     } catch (err) {
       console.error('Failed to load tasks', err);
@@ -742,6 +873,51 @@ function App({ me, onSignOut }){
     TARGET_USER_ID = targetUserId;
     TARGET_USER_NAME = targetUserName;
   }, [targetUserId, targetUserName]);
+
+  useEffect(() => {
+    if (calendarMode === 'all') {
+      setCalendarSelectValue('__all__');
+      return;
+    }
+    if (activeProgramId) {
+      setCalendarSelectValue(String(activeProgramId));
+    } else {
+      setCalendarSelectValue('__current__');
+    }
+  }, [calendarMode, activeProgramId]);
+
+  useEffect(() => {
+    if (!allCalendarPrograms.length) {
+      setProgramVisibility((prev) => (Object.keys(prev).length ? {} : prev));
+      return;
+    }
+    setProgramVisibility((prev) => {
+      const availableIds = new Set(allCalendarPrograms.map((program) => String(program.programId)));
+      let changed = false;
+      const next = { ...prev };
+      allCalendarPrograms.forEach((program) => {
+        const id = String(program.programId);
+        if (!Object.prototype.hasOwnProperty.call(next, id)) {
+          next[id] = true;
+          changed = true;
+        }
+      });
+      Object.keys(next).forEach((id) => {
+        if (!availableIds.has(id)) {
+          delete next[id];
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [allCalendarPrograms]);
+
+  useEffect(() => {
+    calendarCacheRef.current.clear();
+    setAllCalendarEvents([]);
+    setAllCalendarPrograms([]);
+    setProgramVisibility({});
+  }, [targetUserId]);
 
   useEffect(() => {
     const handleJournalUpdate = (event) => {
@@ -784,6 +960,30 @@ function App({ me, onSignOut }){
         });
         return found ? nextWeeks : prevWeeks;
       });
+      setAllCalendarEvents((prevEvents) => {
+        let changed = false;
+        const nextEvents = prevEvents.map((event) => {
+          if (!sameId(event.task_id || event.id, taskId)) return event;
+          changed = true;
+          return {
+            ...event,
+            journal_entry: typeof journalEntry !== 'undefined'
+              ? ensureDisplayValue(journalEntry)
+              : event.journal_entry,
+            responsible_person: typeof responsiblePerson !== 'undefined'
+              ? ensureDisplayValue(responsiblePerson)
+              : event.responsible_person,
+            scheduled_time: typeof scheduledTime !== 'undefined'
+              ? normalizeTimeValue(scheduledTime)
+              : event.scheduled_time,
+            scheduled_for: typeof scheduledFor !== 'undefined'
+              ? scheduledFor
+              : event.scheduled_for,
+          };
+        });
+        return changed ? nextEvents : prevEvents;
+      });
+      calendarCacheRef.current.clear();
     };
 
     window.addEventListener('orientation:journal:update', handleJournalUpdate);
@@ -849,6 +1049,10 @@ function App({ me, onSignOut }){
         byWeek[wk] = { id: uid(), wk, title:'', theme:'', result:'', purpose:'', actions:'', tasks: [] };
       }
       const scheduledTime = deriveTimeFromRow(r);
+      const programId = r.program_id || QS_PROGRAM_ID || '';
+      const info = programInfoMap.get(String(programId)) || null;
+      const programName = info?.name || r.program_name || r.program_title || r.program || '';
+      const programColor = info?.color || r.program_color || r.color || null;
       byWeek[wk].tasks.push({
         id: r.task_id,
         task_id: r.task_id,
@@ -861,18 +1065,26 @@ function App({ me, onSignOut }){
         week_number: typeof r.week_number === 'number' ? r.week_number : ensureDisplayValue(r.week_number),
         journal_entry: ensureDisplayValue(r.journal_entry),
         responsible_person: ensureDisplayValue(r.responsible_person),
-        done: typeof r.done === 'boolean' ? r.done : ensureDisplayValue(r.done)
+        done: typeof r.done === 'boolean' ? r.done : ensureDisplayValue(r.done),
+        program_id: programId ? String(programId) : '',
+        program_name: programName,
+        program_color: programColor
       });
     });
     return Object.values(byWeek).sort((a,b)=> a.wk - b.wk);
   }
 
   async function reloadTasks(){
-    if(!QS_PROGRAM_ID) return 0;
+    if(!QS_PROGRAM_ID){
+      setActiveProgramId(null);
+      return 0;
+    }
+    setActiveProgramId(QS_PROGRAM_ID);
     const rows = await apiGetTasks({ program_id: QS_PROGRAM_ID, include_deleted: true });
     const active = rows.filter(r => !r.deleted);
     setWeeks(buildWeeks(active));
     setDeletedTasks(rows.filter(r => r.deleted));
+    calendarCacheRef.current.clear();
     return active.length;
   }
 
@@ -920,6 +1132,7 @@ useEffect(() => {
       if (pid) {
         // 3) Persist + tell server so future logins restore correctly
         QS_PROGRAM_ID = pid;
+        setActiveProgramId(QS_PROGRAM_ID);
         localStorage.setItem('anx_program_id', pid);
         try { await apiPatchPrefs({ program_id: pid }); } catch (e) {}
 
@@ -932,6 +1145,7 @@ useEffect(() => {
         setWeeks([]);
         setDeletedTasks([]);
         setNeedsInstantiate(false);
+        setActiveProgramId(null);
       }
     } catch (err) {
       console.error('Failed to load tasks', err);
@@ -968,34 +1182,89 @@ useEffect(() => {
     return {done, total, pct: Math.round(100*done/total)};
   }, [weeks]);
 
-  const calDays = useMemo(()=>{
-    const s = dayjs(startDate).startOf('week');
+  const calendarRange = useMemo(() => {
+    const startOfGrid = dayjs(startDate).startOf('week');
     const totalDays = Math.max(7, numWeeks * 7);
-    return Array.from({length: totalDays}, (_,i)=> s.add(i,'day'));
+    const endOfGrid = startOfGrid.add(totalDays - 1, 'day');
+    return {
+      start: startOfGrid,
+      end: endOfGrid,
+      totalDays,
+      key: `${startOfGrid.format('YYYY-MM-DD')}|${endOfGrid.format('YYYY-MM-DD')}`
+    };
   }, [startDate, numWeeks]);
+
+  const calDays = useMemo(()=>{
+    return Array.from({length: calendarRange.totalDays}, (_,i)=> calendarRange.start.add(i,'day'));
+  }, [calendarRange]);
+
+  const singleProgramCalendarEvents = useMemo(() => {
+    const events = [];
+    weeks.forEach((week, wi) => {
+      (week.tasks || []).forEach((task, ti) => {
+        if (!task || !task.scheduled_for) return;
+        const scheduledTime = deriveTimeFromTask(task);
+        const programId = task.program_id || activeProgramId || '';
+        const info = programInfoMap.get(String(programId)) || null;
+        const programName = info?.name || task.program_name || 'Program';
+        const programColor = info?.color || task.program_color || null;
+        const palette = getProgramPalette(programId, programColor);
+        const weekValue = typeof task.week_number === 'number' ? task.week_number : ensureDisplayValue(task.week_number);
+        const title = task.title || task.label || 'Untitled Task';
+        const label = weekValue && weekValue !== '—' ? `W${weekValue}: ${title}` : title;
+        events.push({
+          id: task.task_id || task.id,
+          task_id: task.task_id || task.id,
+          label,
+          title,
+          done: typeof task.done === 'boolean' ? task.done : task.completed,
+          wi,
+          ti,
+          labels: toLabelString(task.labels),
+          week: weekValue,
+          journal_entry: ensureDisplayValue(task.journal_entry),
+          responsible_person: ensureDisplayValue(task.responsible_person),
+          scheduled_for: ensureDisplayValue(task.scheduled_for),
+          scheduled_time: scheduledTime,
+          programId: programId ? String(programId) : '',
+          programName,
+          palette,
+          source: 'single'
+        });
+      });
+    });
+    return events;
+  }, [weeks, activeProgramId, programInfoMap, getProgramPalette]);
+
+  const visibleProgramSet = useMemo(() => {
+    const entries = Object.entries(programVisibility || {});
+    if (!entries.length) return new Set();
+    return new Set(entries.filter(([, value]) => value !== false).map(([id]) => String(id)));
+  }, [programVisibility]);
+
+  const calendarEvents = calendarMode === 'all' ? allCalendarEvents : singleProgramCalendarEvents;
+
+  const legendPrograms = useMemo(() => (
+    Array.isArray(allCalendarPrograms)
+      ? [...allCalendarPrograms].sort((a, b) => (a.programName || '').localeCompare(b.programName || ''))
+      : []
+  ), [allCalendarPrograms]);
 
   const scheduledMap = useMemo(()=>{
     const map = {};
-    weeks.forEach((w, wi)=> (w.tasks||[]).forEach((t,ti)=>{
-      if(t.scheduled_for){
-        const key = dayjs(t.scheduled_for).format('YYYY-MM-DD');
-        map[key] = map[key] || [];
-        const scheduledTime = deriveTimeFromTask(t);
-        map[key].push({
-          label:`W${w.wk}: ${t.title}`,
-          done: typeof t.done === 'boolean' ? t.done : t.completed,
-          wi,
-          ti,
-          task_id: t.task_id,
-          labels: toLabelString(t.labels),
-          week: typeof t.week_number === 'number' ? t.week_number : ensureDisplayValue(t.week_number),
-          journal_entry: ensureDisplayValue(t.journal_entry),
-          responsible_person: ensureDisplayValue(t.responsible_person),
-          scheduled_for: ensureDisplayValue(t.scheduled_for),
-          scheduled_time: scheduledTime
-        });
+    calendarEvents.forEach((event) => {
+      if (!event || !event.scheduled_for) return;
+      if (calendarMode === 'all' && visibleProgramSet.size && !visibleProgramSet.has(String(event.programId || ''))) {
+        return;
       }
-    }));
+      const key = dayjs(event.scheduled_for).format('YYYY-MM-DD');
+      map[key] = map[key] || [];
+      map[key].push(event);
+      if (!event.palette && event.programId) {
+        const info = programInfoMap.get(String(event.programId)) || null;
+        event.palette = getProgramPalette(event.programId, info?.color || null);
+      }
+    });
     Object.keys(map).forEach((key) => {
       map[key].sort((a, b) => {
         const aTime = a.scheduled_time || '';
@@ -1008,11 +1277,94 @@ useEffect(() => {
         } else if (!aTime && bTime) {
           return 1;
         }
-        return a.label.localeCompare(b.label);
+        return (a.label || '').localeCompare(b.label || '');
       });
     });
     return map;
-  }, [weeks]);
+  }, [calendarEvents, calendarMode, visibleProgramSet, programInfoMap, getProgramPalette]);
+
+  useEffect(() => {
+    if (calendarMode !== 'all') return;
+    let cancelled = false;
+    const userKey = targetUserId ? String(targetUserId) : 'self';
+    const cacheKey = `all|${calendarRange.key}|${userKey}`;
+    const applyData = (payload = { events: [], programs: [] }) => {
+      if (cancelled) return;
+      setAllCalendarEvents(payload.events || []);
+      setAllCalendarPrograms(payload.programs || []);
+    };
+    const cached = calendarCacheRef.current.get(cacheKey);
+    if (cached) {
+      applyData(cached);
+      return () => { cancelled = true; };
+    }
+    (async () => {
+      try {
+        const rows = await apiGetTasks({ include_deleted: false });
+        if (cancelled) return;
+        const dedupe = new Map();
+        (Array.isArray(rows) ? rows : []).forEach((row) => {
+          if (!row || row.deleted || !row.scheduled_for) return;
+          const date = dayjs(row.scheduled_for);
+          if (!date.isValid()) return;
+          if (date.isBefore(calendarRange.start, 'day') || date.isAfter(calendarRange.end, 'day')) return;
+          const dedupeKey = `${row.task_id || row.id || row.guid || row.uuid || ''}::${row.program_id || ''}::${date.format('YYYY-MM-DD')}`;
+          if (!dedupe.has(dedupeKey)) {
+            dedupe.set(dedupeKey, row);
+          }
+        });
+        const events = [];
+        const programMap = new Map();
+        dedupe.forEach((row) => {
+          const programIdRaw = row.program_id || row.programId || '';
+          const programId = programIdRaw ? String(programIdRaw) : '';
+          const info = programInfoMap.get(programId) || null;
+          const fallbackName = row.program_name || row.program_title || row.program || 'Program';
+          const fallbackColor = row.program_color || row.color || null;
+          const programName = info?.name || fallbackName;
+          const programColor = info?.color || fallbackColor;
+          const palette = getProgramPalette(programId, programColor);
+          const weekValue = typeof row.week_number === 'number' ? row.week_number : ensureDisplayValue(row.week_number);
+          const title = row.label || row.title || 'Untitled Task';
+          const label = weekValue && weekValue !== '—' ? `W${weekValue}: ${title}` : title;
+          const scheduledTime = deriveTimeFromRow(row);
+          const doneValue = typeof row.done === 'boolean' ? row.done : row.completed;
+          events.push({
+            id: row.task_id || row.id,
+            task_id: row.task_id || row.id,
+            label,
+            title,
+            done: doneValue,
+            wi: null,
+            ti: null,
+            labels: toLabelString(row.labels),
+            week: weekValue,
+            journal_entry: ensureDisplayValue(row.journal_entry),
+            responsible_person: ensureDisplayValue(row.responsible_person),
+            scheduled_for: ensureDisplayValue(row.scheduled_for),
+            scheduled_time: scheduledTime,
+            programId,
+            programName,
+            palette,
+            source: 'all'
+          });
+          if (programId && !programMap.has(programId)) {
+            programMap.set(programId, { programId, programName, palette });
+          }
+        });
+        const programsList = Array.from(programMap.values()).sort((a, b) => (a.programName || '').localeCompare(b.programName || ''));
+        const payload = { events, programs: programsList };
+        calendarCacheRef.current.set(cacheKey, payload);
+        applyData(payload);
+      } catch (err) {
+        console.error('Failed to load all program calendar events', err);
+        applyData({ events: [], programs: [] });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [calendarMode, calendarRange, targetUserId, programInfoMap, getProgramPalette]);
 
   async function refreshPrograms(newId){
     try {
@@ -1025,6 +1377,7 @@ useEffect(() => {
       }
       if(QS_PROGRAM_ID){
         localStorage.setItem('anx_program_id', QS_PROGRAM_ID);
+        setActiveProgramId(QS_PROGRAM_ID);
         try { await apiPatchPrefs({ program_id: QS_PROGRAM_ID }); } catch(e){}
         const count = await reloadTasks();
         if(!count){ setNeedsInstantiate(true); }
@@ -1032,6 +1385,7 @@ useEffect(() => {
       } else {
         localStorage.removeItem('anx_program_id');
         setWeeks([]); setDeletedTasks([]); setNeedsInstantiate(false);
+        setActiveProgramId(null);
       }
       await updateUserPrograms(list);
     } catch(err){
@@ -1080,18 +1434,119 @@ useEffect(() => {
     }
   }
 
-  async function setTaskDate(wi, ti, date, taskId){
+  async function setTaskDate(wi, ti, date, taskId, options = {}){
+    const { onOptimistic, onRevert } = options;
     const prevWeeks = structuredClone(weeks);
-    setWeeks(prev => {
-      const clone = structuredClone(prev);
-      if (clone[wi]?.tasks?.[ti]) clone[wi].tasks[ti].scheduled_for = date;
-      return clone;
-    });
-    if (!taskId) { setWeeks(prevWeeks); alert('Failed to save scheduled date'); return; }
+    let updatedWeeks = false;
+    const clone = structuredClone(weeks);
+    if (typeof wi === 'number' && typeof ti === 'number' && clone[wi]?.tasks?.[ti]) {
+      clone[wi].tasks[ti].scheduled_for = date;
+      updatedWeeks = true;
+    } else if (taskId) {
+      outer: for (let w = 0; w < clone.length; w += 1) {
+        const tasks = clone[w]?.tasks || [];
+        for (let idx = 0; idx < tasks.length; idx += 1) {
+          if (sameId(tasks[idx]?.task_id || tasks[idx]?.id, taskId)) {
+            tasks[idx].scheduled_for = date;
+            updatedWeeks = true;
+            break outer;
+          }
+        }
+      }
+    }
+    if (updatedWeeks) {
+      setWeeks(clone);
+    }
+    const updatedTask = clone.flatMap((week) => week.tasks || []).find((t) => sameId(t?.task_id || t?.id, taskId));
+    if (updatedTask) {
+      const programId = updatedTask.program_id || activeProgramId || '';
+      const info = programInfoMap.get(String(programId)) || null;
+      const programName = info?.name || updatedTask.program_name || 'Program';
+      const programColor = info?.color || updatedTask.program_color || null;
+      const palette = getProgramPalette(programId, programColor);
+      const weekValue = typeof updatedTask.week_number === 'number' ? updatedTask.week_number : ensureDisplayValue(updatedTask.week_number);
+      const title = updatedTask.title || updatedTask.label || 'Untitled Task';
+      const label = weekValue && weekValue !== '—' ? `W${weekValue}: ${title}` : title;
+      const scheduledTime = deriveTimeFromTask(updatedTask);
+      setAllCalendarEvents((prevEvents) => {
+        const index = prevEvents.findIndex((event) => sameId(event.task_id || event.id, taskId));
+        if (!updatedTask.scheduled_for) {
+          if (index === -1) return prevEvents;
+          const next = [...prevEvents];
+          next.splice(index, 1);
+          return next;
+        }
+        if (index === -1) {
+          return [
+            ...prevEvents,
+            {
+              id: updatedTask.task_id || updatedTask.id,
+              task_id: updatedTask.task_id || updatedTask.id,
+              label,
+              title,
+              done: typeof updatedTask.done === 'boolean' ? updatedTask.done : updatedTask.completed,
+              wi: null,
+              ti: null,
+              labels: toLabelString(updatedTask.labels),
+              week: weekValue,
+              journal_entry: ensureDisplayValue(updatedTask.journal_entry),
+              responsible_person: ensureDisplayValue(updatedTask.responsible_person),
+              scheduled_for: updatedTask.scheduled_for || '',
+              scheduled_time: scheduledTime,
+              programId: programId ? String(programId) : '',
+              programName,
+              palette,
+              source: 'all'
+            }
+          ];
+        }
+        const next = [...prevEvents];
+        next[index] = {
+          ...next[index],
+          label,
+          title,
+          done: typeof updatedTask.done === 'boolean' ? updatedTask.done : updatedTask.completed,
+          labels: toLabelString(updatedTask.labels),
+          week: weekValue,
+          journal_entry: ensureDisplayValue(updatedTask.journal_entry),
+          responsible_person: ensureDisplayValue(updatedTask.responsible_person),
+          scheduled_for: updatedTask.scheduled_for || '',
+          scheduled_time: scheduledTime,
+          programId: programId ? String(programId) : '',
+          programName,
+          palette
+        };
+        return next;
+      });
+      if (programId) {
+        setAllCalendarPrograms((prevPrograms) => {
+          if (prevPrograms.some((program) => String(program.programId) === String(programId))) {
+            return prevPrograms;
+          }
+          return [...prevPrograms, { programId: String(programId), programName, palette }];
+        });
+      }
+    }
+    if (typeof onOptimistic === 'function') {
+      onOptimistic();
+    }
+    if (!taskId) {
+      if (updatedWeeks) setWeeks(prevWeeks);
+      if (typeof onRevert === 'function') onRevert();
+      alert('Failed to save scheduled date');
+      return;
+    }
     try {
       const row = await apiPatchScheduledFor(taskId, date);
-      if (!row || !row.task_id) { setWeeks(prevWeeks); alert('Failed to save scheduled date'); }
-    } catch (err) { setWeeks(prevWeeks); alert('Failed to save scheduled date'); }
+      if (!row || !row.task_id) {
+        throw new Error('Empty response');
+      }
+      calendarCacheRef.current.clear();
+    } catch (err) {
+      if (updatedWeeks) setWeeks(prevWeeks);
+      if (typeof onRevert === 'function') onRevert();
+      alert('Failed to save scheduled date');
+    }
   }
 
   function toggleTask(wi, ti){
@@ -1099,11 +1554,31 @@ useEffect(() => {
     if(!task) return;
     const prevValue = task.completed;
     const taskId = task.task_id;
+    const revertAll = () => {
+      setAllCalendarEvents((prevEvents) => {
+        let changed = false;
+        const next = prevEvents.map((event) => {
+          if (!sameId(event.task_id || event.id, taskId)) return event;
+          changed = true;
+          return { ...event, done: prevValue };
+        });
+        return changed ? next : prevEvents;
+      });
+    };
     setWeeks(prev => {
       const clone = structuredClone(prev);
       const t = clone[wi]?.tasks?.[ti];
       if(t) t.completed = !prevValue;
       return clone;
+    });
+    setAllCalendarEvents((prevEvents) => {
+      let changed = false;
+      const next = prevEvents.map((event) => {
+        if (!sameId(event.task_id || event.id, taskId)) return event;
+        changed = true;
+        return { ...event, done: !prevValue };
+      });
+      return changed ? next : prevEvents;
     });
     apiPatchTask(taskId, { done: !prevValue }).then(row => {
       if(!row){
@@ -1113,6 +1588,7 @@ useEffect(() => {
           if(t) t.completed = prevValue;
           return clone;
         });
+        revertAll();
       }
     }).catch(err => {
       console.error('Failed to update task completion', err);
@@ -1122,6 +1598,7 @@ useEffect(() => {
         if(t) t.completed = prevValue;
         return clone;
       });
+      revertAll();
     });
   }
 
@@ -1137,6 +1614,10 @@ useEffect(() => {
       if(!created) return;
       setWeeks(prev => {
         const clone = structuredClone(prev);
+        const programId = created.program_id || QS_PROGRAM_ID || '';
+        const info = programInfoMap.get(String(programId)) || null;
+        const programName = info?.name || created.program_name || '';
+        const programColor = info?.color || created.program_color || null;
         const task = {
           id: created.task_id,
           task_id: created.task_id,
@@ -1149,12 +1630,16 @@ useEffect(() => {
           week_number: typeof created.week_number === 'number' ? created.week_number : ensureDisplayValue(created.week_number),
           journal_entry: ensureDisplayValue(created.journal_entry),
           responsible_person: ensureDisplayValue(created.responsible_person),
-          done: typeof created.done === 'boolean' ? created.done : ensureDisplayValue(created.done)
+          done: typeof created.done === 'boolean' ? created.done : ensureDisplayValue(created.done),
+          program_id: programId ? String(programId) : '',
+          program_name: programName,
+          program_color: programColor
         };
         clone[wi].tasks = clone[wi].tasks || [];
         clone[wi].tasks.push(task);
         return clone;
       });
+      calendarCacheRef.current.clear();
     } catch(err){
       console.error('Failed to create task', err);
       alert('Failed to create task');
@@ -1175,6 +1660,8 @@ useEffect(() => {
         return copy;
       });
       setDeletedTasks(dt => [...dt, { ...task, label: task.title, week_number: weekNumber }]);
+      setAllCalendarEvents(prev => prev.filter(event => !sameId(event.task_id || event.id, task.task_id)));
+      calendarCacheRef.current.clear();
     } catch(err){
       console.error('Failed to delete task', err);
       alert('Failed to delete task');
@@ -1189,6 +1676,10 @@ useEffect(() => {
       setWeeks(ws => {
         const copy = ws.map(w => ({ ...w, tasks: [...(w.tasks||[])] }));
         const wi = copy.findIndex(w => w.wk === res.week_number);
+        const programId = res.program_id || QS_PROGRAM_ID || '';
+        const info = programInfoMap.get(String(programId)) || null;
+        const programName = info?.name || res.program_name || '';
+        const programColor = info?.color || res.program_color || null;
         const newTask = {
           id: res.task_id,
           task_id: res.task_id,
@@ -1201,7 +1692,10 @@ useEffect(() => {
           week_number: typeof res.week_number === 'number' ? res.week_number : ensureDisplayValue(res.week_number),
           journal_entry: ensureDisplayValue(res.journal_entry),
           responsible_person: ensureDisplayValue(res.responsible_person),
-          done: typeof res.done === 'boolean' ? res.done : ensureDisplayValue(res.done)
+          done: typeof res.done === 'boolean' ? res.done : ensureDisplayValue(res.done),
+          program_id: programId ? String(programId) : '',
+          program_name: programName,
+          program_color: programColor
         };
         if (wi !== -1) {
           copy[wi].tasks.push(newTask);
@@ -1211,6 +1705,53 @@ useEffect(() => {
         }
         return copy;
       });
+      if (res.scheduled_for) {
+        const programId = res.program_id || QS_PROGRAM_ID || '';
+        const info = programInfoMap.get(String(programId)) || null;
+        const programName = info?.name || res.program_name || '';
+        const programColor = info?.color || res.program_color || null;
+        const palette = getProgramPalette(programId, programColor);
+        const weekValue = typeof res.week_number === 'number' ? res.week_number : ensureDisplayValue(res.week_number);
+        const title = res.label || 'Untitled Task';
+        const label = weekValue && weekValue !== '—' ? `W${weekValue}: ${title}` : title;
+        const scheduledTime = deriveTimeFromRow(res);
+        setAllCalendarEvents((prevEvents) => {
+          if (prevEvents.some((event) => sameId(event.task_id || event.id, res.task_id))) {
+            return prevEvents;
+          }
+          return [
+            ...prevEvents,
+            {
+              id: res.task_id,
+              task_id: res.task_id,
+              label,
+              title,
+              done: typeof res.done === 'boolean' ? res.done : res.completed,
+              wi: null,
+              ti: null,
+              labels: toLabelString(res.labels),
+              week: weekValue,
+              journal_entry: ensureDisplayValue(res.journal_entry),
+              responsible_person: ensureDisplayValue(res.responsible_person),
+              scheduled_for: res.scheduled_for || '',
+              scheduled_time: scheduledTime,
+              programId: programId ? String(programId) : '',
+              programName,
+              palette,
+              source: 'all'
+            }
+          ];
+        });
+        if (programId) {
+          setAllCalendarPrograms((prevPrograms) => {
+            if (prevPrograms.some((program) => String(program.programId) === String(programId))) {
+              return prevPrograms;
+            }
+            return [...prevPrograms, { programId: String(programId), programName, palette }];
+          });
+        }
+      }
+      calendarCacheRef.current.clear();
     } catch(err){
       console.error('Failed to restore task', err);
       alert('Failed to restore task');
@@ -1225,10 +1766,62 @@ useEffect(() => {
     });
   }
 
+  const updateAllCalendarEventDate = (taskId, nextDate) => {
+    setAllCalendarEvents((prevEvents) => {
+      let changed = false;
+      const next = prevEvents.map((event) => {
+        if (!sameId(event.task_id || event.id, taskId)) return event;
+        changed = true;
+        return {
+          ...event,
+          scheduled_for: nextDate || ''
+        };
+      });
+      return changed ? next : prevEvents;
+    });
+  };
+
+  const handleProgramSelectChange = (event) => {
+    const value = event.target.value;
+    if (value === '__all__') {
+      setCalendarMode('all');
+      setCalendarSelectValue('__all__');
+      return;
+    }
+    setCalendarMode('single');
+    if (value === '__current__') {
+      setCalendarSelectValue(activeProgramId ? String(activeProgramId) : '__current__');
+      return;
+    }
+    setCalendarSelectValue(value);
+    if (!sameId(value, QS_PROGRAM_ID)) {
+      refreshPrograms(value);
+    }
+  };
+
+  const toggleProgramVisibility = (programId) => {
+    const id = String(programId);
+    setProgramVisibility((prev) => {
+      const next = { ...prev };
+      const current = Object.prototype.hasOwnProperty.call(next, id) ? next[id] : true;
+      next[id] = !current;
+      return next;
+    });
+  };
+
   function handleDragStart(e){
     if (!(hasPerm('task.assign') && isPrivileged && !isTrainee)) return;
-    const { wi, ti, taskid } = e.currentTarget.dataset;
-    setDragBadge({ wi: Number(wi), ti: Number(ti), task_id: taskid });
+    const { wi, ti, taskid, programId, source, scheduled_for: scheduledFor } = e.currentTarget.dataset;
+    const wiNum = typeof wi !== 'undefined' && wi !== '' ? Number(wi) : null;
+    const tiNum = typeof ti !== 'undefined' && ti !== '' ? Number(ti) : null;
+    setDragBadge({
+      wi: Number.isFinite(wiNum) ? wiNum : null,
+      ti: Number.isFinite(tiNum) ? tiNum : null,
+      task_id: taskid,
+      programId: programId || '',
+      source: source || 'single',
+      scheduled_for: scheduledFor || ''
+    });
   }
   function handleDragEnd(){
     if (!(hasPerm('task.assign') && isPrivileged && !isTrainee)) return;
@@ -1248,7 +1841,21 @@ useEffect(() => {
     e.preventDefault();
     handleDragLeave(e);
     if(dragBadge){
-      setTaskDate(dragBadge.wi, dragBadge.ti, date, dragBadge.task_id);
+      if (dragBadge.source === 'all') {
+        const previousDate = dragBadge.scheduled_for || '';
+        setTaskDate(dragBadge.wi, dragBadge.ti, date, dragBadge.task_id, {
+          onOptimistic: () => {
+            updateAllCalendarEventDate(dragBadge.task_id, date);
+            calendarCacheRef.current.clear();
+          },
+          onRevert: () => {
+            updateAllCalendarEventDate(dragBadge.task_id, previousDate);
+            calendarCacheRef.current.clear();
+          }
+        });
+      } else {
+        setTaskDate(dragBadge.wi, dragBadge.ti, date, dragBadge.task_id);
+      }
       setDragBadge(null);
     }
   }
@@ -1617,7 +2224,79 @@ useEffect(() => {
 
       {/* Calendar */}
       {(
-      <Section title={`${numWeeks}-Week Visual Calendar`} subtitle="Assign tasks by date; click Assign on a day.">
+      <Section
+        title={`${numWeeks}-Week Visual Calendar`}
+        subtitle="Assign tasks by date; click Assign on a day."
+        right={(
+          <div id="calendarControls" className="flex flex-col gap-2 items-stretch md:items-end">
+            <div className="flex items-center gap-2">
+              <label htmlFor="programSelect" className="text-xs font-semibold uppercase tracking-wide text-slate-500">Program View</label>
+              <select
+                id="programSelect"
+                className="input w-48"
+                value={calendarSelectValue}
+                onChange={handleProgramSelectChange}
+              >
+                <option value="__current__">Current Program</option>
+                <option value="__all__">All Programs</option>
+                {userPrograms.map((program) => (
+                  <option key={program.program_id} value={program.program_id}>
+                    {program.title}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div
+              id="programFilter"
+              hidden={calendarMode !== 'all'}
+              className={`flex flex-wrap gap-2 ${calendarMode === 'all' ? '' : 'hidden'}`}
+            >
+              {legendPrograms.length ? legendPrograms.map((program) => {
+                const checked = programVisibility[String(program.programId)] !== false;
+                return (
+                  <label
+                    key={`filter-${program.programId}`}
+                    className={`flex items-center gap-2 rounded-full border px-2 py-1 text-[11px] cursor-pointer transition ${checked ? 'bg-white shadow-sm border-slate-200' : 'bg-white/70 border-slate-200 opacity-70'}`}
+                  >
+                    <input
+                      type="checkbox"
+                      className="sr-only"
+                      checked={checked}
+                      onChange={() => toggleProgramVisibility(program.programId)}
+                    />
+                    <span className="inline-flex items-center gap-1">
+                      <span
+                        className="inline-block w-2 h-2 rounded-full"
+                        style={{ backgroundColor: program.palette?.dot || '#0ea5e9' }}
+                        aria-hidden="true"
+                      ></span>
+                      <span>{program.programName}</span>
+                    </span>
+                  </label>
+                );
+              }) : (
+                <span className="text-[11px] text-slate-500">No programs available in this range.</span>
+              )}
+            </div>
+            <div
+              id="programLegend"
+              hidden={calendarMode !== 'all'}
+              className={`flex flex-wrap gap-3 text-[11px] text-slate-600 ${calendarMode === 'all' ? '' : 'hidden'}`}
+            >
+              {legendPrograms.map((program) => (
+                <div key={`legend-${program.programId}`} className="flex items-center gap-1">
+                  <span
+                    className="inline-block w-2.5 h-2.5 rounded-full border border-white shadow-sm"
+                    style={{ backgroundColor: program.palette?.dot || '#0ea5e9' }}
+                    aria-hidden="true"
+                  ></span>
+                  <span>{program.programName}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      >
         <div className="grid grid-cols-7 gap-2 text-xs font-medium text-slate-500 mb-2">
           {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map(d=> <div key={d} className="text-center">{d}</div>)}
         </div>
@@ -1644,6 +2323,12 @@ useEffect(() => {
                       : String(it.done).toLowerCase() === 'true';
                     const canManageAssignments = hasPerm('task.assign') && isPrivileged && !isTrainee;
                     const isDraggable = canManageAssignments && !isTaskDone;
+                    const isAllView = calendarMode === 'all';
+                    const palette = it.palette;
+                    const itemStyle = !isTaskDone && isAllView && palette
+                      ? { borderColor: palette.border, backgroundColor: palette.background }
+                      : undefined;
+                    const itemClass = `relative text-[11px] pl-2 pr-4 py-1 rounded-md border focus-visible:ring-2 focus-visible:ring-anx-sky ${isTaskDone ? 'bg-emerald-50 border-emerald-300 cursor-not-allowed' : isAllView ? 'cursor-pointer' : 'bg-sky-50 border-sky-300 cursor-pointer'}`;
                     const tooltipResponsible = toDisplayString(it.responsible_person);
                     const tooltipJournal = toDisplayString(it.journal_entry);
                     const tooltipEntries = [];
@@ -1658,7 +2343,8 @@ useEffect(() => {
                     }
                     return (
                       <div key={i}
-                           className={`relative text-[11px] pl-2 pr-4 py-1 rounded-md border focus-visible:ring-2 focus-visible:ring-anx-sky ${isTaskDone?'bg-emerald-50 border-emerald-300 cursor-not-allowed':'bg-sky-50 border-sky-300 cursor-pointer'}`}
+                           className={itemClass}
+                           style={itemStyle}
                            role="button"
                            tabIndex={isTaskDone ? -1 : 0}
                            aria-describedby={tooltipEntries.length ? tooltipId : undefined}
@@ -1677,9 +2363,22 @@ useEffect(() => {
                            data-scheduled_for={toDisplayString(it.scheduled_for)}
                            data-scheduled_time={it.scheduled_time || ''}
                            data-done={doneAttr}
+                           data-program-id={it.programId || ''}
+                           data-program_name={it.programName || ''}
+                           data-source={isAllView ? 'all' : 'single'}
                            onDragStart={isDraggable ? handleDragStart : undefined} onDragEnd={isDraggable ? handleDragEnd : undefined}
                            onTouchStart={isDraggable ? handleDragStart : undefined} onTouchMove={isDraggable ? handleTouchMove : undefined}
                            onTouchEnd={isDraggable ? handleTouchEnd : undefined} onTouchCancel={isDraggable ? handleTouchEnd : undefined}>
+                        {isAllView && (
+                          <div className="flex items-center gap-1 text-[10px] text-slate-600 mb-0.5">
+                            <span
+                              className="inline-block w-2 h-2 rounded-full"
+                              style={{ backgroundColor: palette?.dot || '#0ea5e9' }}
+                              aria-hidden="true"
+                            ></span>
+                            <span className="truncate" title={it.programName || 'Program'}>{it.programName || 'Program'}</span>
+                          </div>
+                        )}
                         <div>{it.label}</div>
                         {it.scheduled_time && (
                           <div className="mt-0.5 text-[10px] text-slate-600">Assigned • {it.scheduled_time}</div>


### PR DESCRIPTION
## Summary
- add client-side state, caching, and fetch logic to support an all-program calendar view with per-program colors and filters
- extend task operations to keep aggregated calendar data and cache in sync across add/delete/update flows
- update the calendar UI with a program selector, filter chips, legend, and color-aware event rendering while preserving existing behaviors

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d0c937b5d4832cbd0a751dbd0538c0