### PR TITLE
Adjust calendar program controls layout

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -2293,25 +2293,26 @@ useEffect(() => {
       <Section
         title={`${numWeeks}-Week Visual Calendar`}
         subtitle="Assign tasks by date; click Assign on a day."
-        right={(
-          <div id="calendarControls" className="flex flex-col gap-2 items-stretch md:items-end">
-            <div className="flex items-center gap-2">
-              <label htmlFor="programSelect" className="text-xs font-semibold uppercase tracking-wide text-slate-500">Program View</label>
-              <select
-                id="programSelect"
-                className="input w-48"
-                value={calendarSelectValue}
-                onChange={handleProgramSelectChange}
-              >
-                <option value="__current__">Current Program</option>
-                <option value="__all__">All Programs</option>
-                {userPrograms.map((program) => (
-                  <option key={program.program_id} value={program.program_id}>
-                    {program.title}
-                  </option>
-                ))}
-              </select>
-            </div>
+      >
+        <div id="calendarControls" className="mb-4 flex flex-col gap-3 rounded-lg bg-slate-50 p-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center">
+            <label htmlFor="programSelect" className="text-xs font-semibold uppercase tracking-wide text-slate-500">Program View</label>
+            <select
+              id="programSelect"
+              className="input w-full md:w-48"
+              value={calendarSelectValue}
+              onChange={handleProgramSelectChange}
+            >
+              <option value="__current__">Current Program</option>
+              <option value="__all__">All Programs</option>
+              {userPrograms.map((program) => (
+                <option key={program.program_id} value={program.program_id}>
+                  {program.title}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-3 md:flex md:flex-1 md:flex-col md:items-end md:space-y-0">
             <div
               id="programFilter"
               hidden={calendarMode !== 'all'}
@@ -2361,8 +2362,7 @@ useEffect(() => {
               ))}
             </div>
           </div>
-        )}
-      >
+        </div>
         <div className="grid grid-cols-7 gap-2 text-xs font-medium text-slate-500 mb-2">
           {['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].map(d=> <div key={d} className="text-center">{d}</div>)}
         </div>
@@ -2857,46 +2857,6 @@ useEffect(() => {
                   {pwMsg && <div className="text-xs text-slate-500">{pwMsg}</div>}
                   <button className="btn btn-primary w-full mt-2" type="submit">Change Password</button>
                 </form>
-              </div>
-            )}
-          </div>
-
-          {/* Programs & Templates */}
-          <div>
-            <h3>
-              <button
-                id="hdr-programs"
-                type="button"
-                className="btn btn-ghost w-full justify-between text-sm font-semibold"
-                aria-expanded={openSections.includes('programs')}
-                aria-controls="sec-programs"
-                onClick={()=> toggleSection('programs')}
-              >
-                <span className="flex items-center gap-2"><span aria-hidden="true">📦</span>Programs & Templates</span>
-                <span className={`transition-transform ${openSections.includes('programs')? 'rotate-180':''}`}>⌄</span>
-              </button>
-            </h3>
-            {openSections.includes('programs') && (
-              <div id="sec-programs" className="mt-2 space-y-3" aria-labelledby="hdr-programs">
-                <div className="space-y-2">
-                  {filteredPrograms.length > 0 ? (
-                    filteredPrograms.map(p => (
-                      <button
-                        key={p.program_id}
-                        type="button"
-                        className="w-full flex items-center gap-2 text-sm px-3 py-2 rounded-xl hover:bg-slate-100 text-left"
-                        onClick={() => refreshPrograms(p.program_id)}
-                      >
-                        <span className="flex items-center gap-2 truncate">
-                          <span aria-hidden="true">{p.icon}</span>
-                          <span className="truncate">{p.title}</span>
-                        </span>
-                      </button>
-                    ))
-                  ) : (
-                    <p className="text-sm text-slate-500">No programs available.</p>
-                  )}
-                </div>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- move the program view controls below the visual calendar subtitle so they sit within the main calendar body
- remove the Programs & Templates accordion from the right-side panel to declutter the sidebar

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d0ddf740e0832ca38d3602b838217f