### PR TITLE
Add template import controls

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -482,6 +482,8 @@
         <div class="flex items-center gap-2 flex-wrap justify-end">
           <button id="btnNewTemplate" class="btn btn-primary text-sm">Add Template</button>
           <button id="btnEditTemplate" class="btn btn-outline text-sm" disabled>Edit Template</button>
+          <input id="inputImportTemplates" type="file" accept=".csv,application/json,.json,text/csv" class="sr-only" />
+          <button id="btnImportTemplates" class="btn btn-outline text-sm">Import Templates</button>
           <button id="btnRefreshTemplates" class="btn btn-outline text-sm">Refresh</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add an Import Templates button and hidden upload input to the admin template toolbar
- parse CSV/JSON template files, call the import API (with sequential fallback), and surface progress/errors via toasts
- refresh the template list after successful imports and keep the new controls aligned with permission state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0e03e1a0c832c89cdd63e3a1da451