### PR TITLE
Make all-program week tasks modal triggers

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -2632,7 +2632,7 @@ useEffect(() => {
               </div>
             ) : (
               combinedWeeksView.length ? (
-                combinedWeeksView.map((week) => {
+                combinedWeeksView.map((week, weekIndex) => {
                   const total = week.tasks.length || 1;
                   const complete = week.tasks.filter((task) => {
                     if (typeof task.done === 'boolean') return task.done;
@@ -2653,7 +2653,7 @@ useEffect(() => {
                         </div>
                       </div>
                       <div className="space-y-3 mt-4">
-                        {week.tasks.map((task) => {
+                        {week.tasks.map((task, taskIndex) => {
                           const taskId = task.task_id || task.id;
                           const programId = task.programId ? String(task.programId) : '';
                           const info = programInfoMap.get(programId) || {};
@@ -2667,16 +2667,41 @@ useEffect(() => {
                           const done = typeof task.done === 'boolean'
                             ? task.done
                             : String(task.done).toLowerCase() === 'true';
+                          const doneAttr = typeof task.done === 'boolean' ? String(task.done) : toDisplayString(task.done);
                           const label = task.label || task.title || 'Untitled Task';
+                          const labelDisplay = toDisplayString(label);
                           const labelTokens = (task.labels || '')
                             .split(',')
                             .map((token) => token.trim())
                             .filter(Boolean);
+                          const weekValue = week.wk === null
+                            ? weekLabel
+                            : (typeof week.wk === 'number' || typeof week.wk === 'string'
+                              ? String(week.wk)
+                              : toDisplayString(week.wk));
                           return (
-                            <div
+                            <button
+                              type="button"
                               key={`${week.id}-${taskId}`}
-                              className="card p-3 border"
+                              className="card p-3 border text-left w-full disabled:cursor-not-allowed"
                               style={palette ? { borderLeft: `4px solid ${palette.border}` } : undefined}
+                              data-task-id={taskId}
+                              data-taskid={taskId}
+                              data-title={labelDisplay}
+                              data-week={weekValue}
+                              data-journal_entry={hasJournal ? journal : ''}
+                              data-responsible_person={hasResponsible ? responsible : ''}
+                              data-scheduled_for={toDisplayString(task.scheduled_for)}
+                              data-scheduled_time={timeDisplay}
+                              data-done={doneAttr}
+                              data-program-id={programId}
+                              data-program_name={task.programName || info.name || 'Program'}
+                              data-source="all"
+                              data-wi={weekIndex}
+                              data-ti={taskIndex}
+                              data-disabled={done ? 'true' : undefined}
+                              disabled={done}
+                              aria-disabled={done ? 'true' : 'false'}
                             >
                               <div className="flex items-start justify-between gap-3">
                                 <div className="flex-1 min-w-0">
@@ -2728,7 +2753,7 @@ useEffect(() => {
                                   <span className="text-xs font-semibold text-emerald-600 whitespace-nowrap">✓ Complete</span>
                                 )}
                               </div>
-                            </div>
+                            </button>
                           );
                         })}
                       </div>


### PR DESCRIPTION
## Summary
- wrap all-program "Weeks & Tasks" cards in button triggers so they can open the modal
- expose the same data attributes and completed-state handling used by single-program tasks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0ebbe0210832cb8229fc78a0df9a1