### PR TITLE
Add organization column to users and expose in RBAC listing

### DIFF
--- a/migrations/013_add_organization_to_users.sql
+++ b/migrations/013_add_organization_to_users.sql
@@ -1,0 +1,3 @@
+-- Adds organization column to public.users so RBAC APIs can surface employer context.
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS organization text;

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -1231,7 +1231,7 @@ app.get('/rbac/users', async (req, res) => {
   try {
     if (!(req.roles.includes('admin') || req.roles.includes('manager'))) return res.status(403).json({ error: 'forbidden' });
     const sql = `
-      select u.id, u.full_name, u.username,
+      select u.id, u.full_name, u.username, u.organization,
              coalesce(array_agg(r.role_key) filter (where r.role_key is not null), '{}') as roles
       from public.users u
       left join public.user_roles ur on ur.user_id = u.id
@@ -2218,6 +2218,7 @@ create table if not exists public.users (
   username     text unique,
   email        text,
   full_name    text,
+  organization text,
   picture_url  text,
   password_hash text,
   password_reset_token text,


### PR DESCRIPTION
## Summary
- add the organization column to the public.users table definition and surface it from /rbac/users
- provide a migration to add the nullable organization column for existing databases

## Testing
- npm test -- --runTestsByPath __tests__/programRoutes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0f572d918832c9d99f6502f0a6a7e