### PR TITLE
Persist scheduling metadata on program assignment

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -451,11 +451,36 @@ export const updateUserRoles = async (id: string, roles: string[]): Promise<User
 export const assignPrograms = (
   id: string,
   payload: { programId: string; startDate: string; dueDate: string; notes?: string },
-) =>
-  apiFetch(`/api/users/${id}/programs`, {
-    method: 'POST',
-    body: JSON.stringify(payload),
-  });
+) => {
+  const { programId, startDate, dueDate, notes } = payload;
+  const requests = useMock
+    ? [
+        {
+          url: `/api/users/${id}/programs`,
+          init: { method: 'POST', body: JSON.stringify(payload) },
+        },
+      ]
+    : [
+        {
+          url: `/rbac/users/${id}/programs/${programId}/instantiate`,
+          init: {
+            method: 'POST',
+            body: JSON.stringify({
+              programId,
+              startDate,
+              dueDate,
+              notes: typeof notes === 'string' ? notes : undefined,
+            }),
+          },
+        },
+        {
+          url: `/api/users/${id}/programs`,
+          init: { method: 'POST', body: JSON.stringify(payload) },
+        },
+      ];
+
+  return attemptRequests<unknown>(requests);
+};
 
 export const deactivateUser = (id: string, reason: string) =>
   apiFetch(`/api/users/${id}/deactivate`, { method: 'POST', body: JSON.stringify({ reason }) });


### PR DESCRIPTION
## Summary
- route API program assignment calls the RBAC instantiate endpoint when mocks are disabled so the backend receives scheduling metadata
- validate incoming scheduling payload on the instantiate route, persist start/due dates and notes onto orientation tasks and user preferences, and backfill columns when missing
- extend the program routes test suite to cover instantiating a program with scheduling details and ensure the values are stored

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1611cb410832c9bc0b839a530df57