### PR TITLE
Add confirm password validation to orientation auth

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -406,6 +406,7 @@ function AuthPanel({ onAuthed }){
   const [mode, setMode] = useState('login');
   const [u, setU] = useState('');
   const [p, setP] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [err, setErr] = useState('');
@@ -421,7 +422,12 @@ function AuthPanel({ onAuthed }){
     onAuthed();
   }
   async function doRegister(e){
-    e.preventDefault(); setErr('');
+    e.preventDefault();
+    if (p !== confirmPassword) {
+      setErr('Passwords do not match.');
+      return;
+    }
+    setErr('');
     const r = await fetch(`${API}/auth/local/register`, {
       method:'POST', headers:{'Content-Type':'application/json'}, credentials:'include',
       body: JSON.stringify({ username: u.trim(), password: p, full_name: name.trim(), email: email.trim() })
@@ -475,6 +481,22 @@ function AuthPanel({ onAuthed }){
             </button>
           </div>
         </div>
+        {mode === 'register' && (
+          <div className="mb-4">
+            <label htmlFor="confirmPassword" className="text-sm block mb-1">Confirm password</label>
+            <input
+              id="confirmPassword"
+              className="input"
+              type={showPassword ? 'text' : 'password'}
+              value={confirmPassword}
+              onChange={e=>setConfirmPassword(e.target.value)}
+              placeholder="••••••••"
+            />
+          </div>
+        )}
+        {err && (
+          <p className="text-sm text-red-600 mb-4" role="alert">{err}</p>
+        )}
               <div className="flex flex-col items-center space-y-2 mt-2">
   {mode === 'login' ? (
     <button className="btn btn-primary w-full" onClick={doLogin}>Sign in</button>


### PR DESCRIPTION
## Summary
- add state to capture confirm password when creating a new local account
- validate matching passwords before registration and surface any error inside the form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1679430c4832caba17c1f1d3d9a43