### PR TITLE
Add due date column to user preferences

### DIFF
--- a/migrations/014_add_due_date_to_user_preferences.sql
+++ b/migrations/014_add_due_date_to_user_preferences.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.user_preferences
+    ADD COLUMN IF NOT EXISTS due_date date,
+    ADD COLUMN IF NOT EXISTS notes text;


### PR DESCRIPTION
## Summary
- add migration to ensure user_preferences table includes due_date and notes columns

## Testing
- not run (database environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d16be08c0c832c9db70e2ea66d6cfa