### PR TITLE
Add organization metadata to programs

### DIFF
--- a/__tests__/templateApi.test.js
+++ b/__tests__/templateApi.test.js
@@ -55,6 +55,8 @@ describe('template api', () => {
         title text not null,
         total_weeks int,
         description text,
+        organization text,
+        sub_unit text,
         created_by uuid,
         created_at timestamptz default now(),
         deleted_at timestamp

--- a/migrations/015_add_organization_to_programs.down.sql
+++ b/migrations/015_add_organization_to_programs.down.sql
@@ -1,0 +1,3 @@
+alter table public.programs
+  drop column if exists organization,
+  drop column if exists sub_unit;

--- a/migrations/015_add_organization_to_programs.sql
+++ b/migrations/015_add_organization_to_programs.sql
@@ -1,0 +1,3 @@
+alter table public.programs
+  add column if not exists organization text,
+  add column if not exists sub_unit text;


### PR DESCRIPTION
## Summary
- add migrations for organization and sub_unit columns on public.programs
- update orientation server fallback DDL and program handlers to support organization metadata
- adjust tests and fixtures to cover the new columns during create/update flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d176698374832c9ce0f77004096de0