### PR TITLE
Validate user_id for PATCH /prefs

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -1214,6 +1214,9 @@ app.patch('/prefs', ensureAuth, async (req, res) => {
     num_weeks,
     trainee
   } = body;
+  if (!isValidUuid(userId)) {
+    return res.status(400).json({ error: 'invalid_user_id' });
+  }
   const { rows: roleRows } = await pool.query(
     'select r.role_key from user_roles ur join roles r on ur.role_id=r.role_id where ur.user_id=$1',
     [userId]


### PR DESCRIPTION
## Summary
- validate the resolved user_id in the PATCH /prefs handler and reject invalid UUIDs before any queries run
- extend the preferences route test suite to cover PATCH /prefs with both valid and invalid user_id values

## Testing
- npx jest prefsRoutesAuth.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d17bacae68832cb2a98a5c82a1dea2