### PR TITLE
Add assigned program metadata to RBAC users and tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,10 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': '<rootDir>/test-utils/esbuild-jest-transform.js',
   },
+  moduleNameMapper: {
+    '^react$': '<rootDir>/test-utils/reactStub.js',
+    '^react/jsx-runtime$': '<rootDir>/test-utils/reactJsxRuntimeStub.js',
+  },
   testMatch: [
     '**/__tests__/**/*.{spec,test}.[tj]s?(x)',
     '**/?(*.)+(spec|test).[tj]s?(x)',

--- a/src/api.ts
+++ b/src/api.ts
@@ -717,6 +717,8 @@ async function mockFetch<T>(url: string, opts?: RequestInit): Promise<T> {
   switch (true) {
     case url.startsWith('/api/users?'):
       return { data: u, meta: { total: u.length, page: 1 } } as any;
+    case url === '/api/users' && method === 'GET':
+      return { data: u, meta: { total: u.length, page: 1 } } as any;
     case url === '/api/users' && method === 'POST':
       return { ...opts?.body && JSON.parse(opts.body.toString()), id: 'u-new' } as any;
     case /^\/api\/users\/[^/]+\/programs$/.test(url) && method === 'POST':

--- a/test-utils/reactJsxRuntimeStub.js
+++ b/test-utils/reactJsxRuntimeStub.js
@@ -1,0 +1,15 @@
+const ReactStub = require('./reactStub');
+
+const jsxFactory = (type, props, key) => {
+  const normalizedProps = props ? { ...props } : {};
+  if (key !== undefined) {
+    normalizedProps.key = key;
+  }
+  return ReactStub.createElement(type, normalizedProps);
+};
+
+module.exports = {
+  jsx: jsxFactory,
+  jsxs: jsxFactory,
+  Fragment: ReactStub.Fragment,
+};


### PR DESCRIPTION
## Summary
- include per-user program assignments in the /rbac/users query and normalize them for the response
- expand the RBAC route test schema and assertions to cover assigned program metadata
- update the frontend test and mocks to exercise real fetches, adding Jest mappings for the React stub runtime

## Testing
- npm test -- rbacRoutes
- npm test -- usersAssignPrograms

------
https://chatgpt.com/codex/tasks/task_e_68d18282e034832ca995b685f17205af