### PR TITLE
Sync task done flag with completion toggle

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -1780,7 +1780,11 @@ useEffect(() => {
     setWeeks(prev => {
       const clone = structuredClone(prev);
       const t = clone[wi]?.tasks?.[ti];
-      if(t) t.completed = !prevValue;
+      if(t){
+        const nextValue = !prevValue;
+        t.completed = nextValue;
+        t.done = nextValue;
+      }
       return clone;
     });
     setAllCalendarEvents((prevEvents) => {
@@ -1797,7 +1801,10 @@ useEffect(() => {
         setWeeks(prev => {
           const clone = structuredClone(prev);
           const t = clone[wi]?.tasks?.[ti];
-          if(t) t.completed = prevValue;
+          if(t){
+            t.completed = prevValue;
+            t.done = prevValue;
+          }
           return clone;
         });
         revertAll();
@@ -1807,7 +1814,10 @@ useEffect(() => {
       setWeeks(prev => {
         const clone = structuredClone(prev);
         const t = clone[wi]?.tasks?.[ti];
-        if(t) t.completed = prevValue;
+        if(t){
+          t.completed = prevValue;
+          t.done = prevValue;
+        }
         return clone;
       });
       revertAll();


### PR DESCRIPTION
## Summary
- ensure toggling a task updates both `completed` and `done` flags so calendar reflects checkbox state immediately
- reset both flags during rollback when the PATCH request fails to keep UI in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1b560bbf0832cabbb189efbe09d6e