### PR TITLE
Add organization filters to program templates

### DIFF
--- a/db/programTemplateLinks.js
+++ b/db/programTemplateLinks.js
@@ -94,6 +94,8 @@ function createProgramTemplateLinksDao(pool) {
       offset = 0,
       includeDeleted = false,
       status,
+      organization,
+      subUnit,
     } = options;
     if (!programId) {
       return { data: [], meta: { total: 0, limit: normalizeLimit(limit), offset: normalizeOffset(offset) } };
@@ -106,6 +108,20 @@ function createProgramTemplateLinksDao(pool) {
       where += ' and t.deleted_at is null';
     }
     where += buildStatusFilter(status, params);
+    if (typeof organization === 'string') {
+      const trimmed = organization.trim();
+      if (trimmed) {
+        params.push(trimmed.toLowerCase());
+        where += ` and lower(coalesce(t.organization, '')) = $${params.length}`;
+      }
+    }
+    if (typeof subUnit === 'string') {
+      const trimmed = subUnit.trim();
+      if (trimmed) {
+        params.push(trimmed.toLowerCase());
+        where += ` and lower(coalesce(t.sub_unit, '')) = $${params.length}`;
+      }
+    }
     const filterParams = params.slice();
     params.push(normalizedLimit);
     params.push(normalizedOffset);
@@ -115,6 +131,8 @@ function createProgramTemplateLinksDao(pool) {
              t.status,
              t.deleted_at,
              t.external_link as external_link,
+             t.organization,
+             t.sub_unit,
              l.program_id,
              l.id as link_id,
              l.created_at,

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -971,12 +971,23 @@ apiRouter.get('/programs/:programId/templates', ensurePerm('template.read'), asy
       }
       status = normalizedStatus;
     }
+    const organizationParam = typeof req.query?.organization === 'string' ? req.query.organization : undefined;
+    const subUnitParam =
+      typeof req.query?.sub_unit === 'string'
+        ? req.query.sub_unit
+        : typeof req.query?.subUnit === 'string'
+          ? req.query.subUnit
+          : undefined;
+    const organization = organizationParam ? organizationParam.trim() : undefined;
+    const subUnit = subUnitParam ? subUnitParam.trim() : undefined;
     const result = await programTemplateLinksDao.listTemplatesForProgram({
       programId,
       includeDeleted,
       limit: req.query?.limit,
       offset: req.query?.offset,
       status,
+      organization: organization || undefined,
+      subUnit: subUnit || undefined,
     });
     res.json(result);
   } catch (err) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -24,6 +24,8 @@ export interface Template {
   updatedAt?: string;
   status?: 'draft' | 'published' | 'deprecated';
   deletedAt?: string | null;
+  organization: string | null;
+  subUnit: string | null;
 }
 
 type UserListResponse = { data: User[]; meta: { total: number; page: number } };
@@ -338,7 +340,7 @@ const normalizeProgramList = (payload: unknown): ProgramListResponse => {
 
 const normalizeTemplate = (raw: any): Template => {
   if (!raw || typeof raw !== 'object') {
-    return { id: '', programId: '', name: '', category: 'General' };
+    return { id: '', programId: '', name: '', category: 'General', organization: null, subUnit: null };
   }
 
   const idCandidate = raw.id ?? raw.template_id ?? raw.uid ?? '';
@@ -350,6 +352,35 @@ const normalizeTemplate = (raw: any): Template => {
     ? (statusCandidate as Template['status'])
     : undefined;
   const updatedCandidate = raw.updatedAt ?? raw.updated_at ?? raw.updated ?? raw.modified_at ?? null;
+  const organizationSource =
+    raw.organization ??
+    raw.org ??
+    raw.organization_name ??
+    raw.organizationName ??
+    raw.org_name ??
+    null;
+  let organization: string | null = null;
+  if (typeof organizationSource === 'string') {
+    const trimmed = organizationSource.trim();
+    organization = trimmed ? trimmed : null;
+  } else if (organizationSource === null) {
+    organization = null;
+  }
+  const subUnitSource =
+    raw.subUnit ??
+    raw.sub_unit ??
+    raw.subunit ??
+    raw.subUnitName ??
+    raw.sub_unit_name ??
+    raw.department ??
+    null;
+  let subUnit: string | null = null;
+  if (typeof subUnitSource === 'string') {
+    const trimmed = subUnitSource.trim();
+    subUnit = trimmed ? trimmed : null;
+  } else if (subUnitSource === null) {
+    subUnit = null;
+  }
 
   const template: Template = {
     id: String(idCandidate ?? ''),
@@ -359,6 +390,8 @@ const normalizeTemplate = (raw: any): Template => {
         ? String(nameCandidate)
         : `Template ${String(idCandidate ?? '')}`,
     category: String(categoryCandidate ?? 'General'),
+    organization,
+    subUnit,
   };
   const parsedDate = toDateString(updatedCandidate);
   if (parsedDate) {
@@ -431,7 +464,15 @@ const buildProgramWritePayload = (payload: Partial<Program>): Record<string, unk
 };
 
 const buildTemplateWritePayload = (payload: Partial<Template>): Record<string, unknown> => {
-  const { id: _id, programId: _programId, updatedAt: _updatedAt, deletedAt: _deletedAt, ...rest } = payload;
+  const {
+    id: _id,
+    programId: _programId,
+    updatedAt: _updatedAt,
+    deletedAt: _deletedAt,
+    organization,
+    subUnit,
+    ...rest
+  } = payload;
   const body: Record<string, unknown> = { ...rest };
   if (payload.name && !body.label) {
     body.label = payload.name;
@@ -443,6 +484,22 @@ const buildTemplateWritePayload = (payload: Partial<Template>): Record<string, u
     const normalized = payload.status.toLowerCase() as Template['status'];
     if (TEMPLATE_STATUS_SET.has(normalized as NonNullable<Template['status']>)) {
       body.status = normalized;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, 'organization')) {
+    if (typeof organization === 'string') {
+      const trimmed = organization.trim();
+      body.organization = trimmed ? trimmed : null;
+    } else if (organization === null) {
+      body.organization = null;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, 'subUnit')) {
+    if (typeof subUnit === 'string') {
+      const trimmed = subUnit.trim();
+      body.sub_unit = trimmed ? trimmed : null;
+    } else if (subUnit === null) {
+      body.sub_unit = null;
     }
   }
   return body;
@@ -728,10 +785,14 @@ export const cloneProgram = (id: string) =>
 
 export const getProgramTemplates = async (
   programId: string,
-  params: { includeDeleted?: boolean } = {},
+  params: { includeDeleted?: boolean; organization?: string | null; subUnit?: string | null } = {},
 ): Promise<TemplateListResponse> => {
   const search = new URLSearchParams();
   if (params.includeDeleted) search.set('include_deleted', 'true');
+  const organization = params.organization?.trim();
+  if (organization) search.set('organization', organization);
+  const subUnit = params.subUnit?.trim();
+  if (subUnit) search.set('sub_unit', subUnit);
   const query = search.toString();
   const raw = await apiFetch<unknown>(
     `${programTemplatesBase(programId)}${query ? `?${query}` : ''}`,
@@ -821,9 +882,32 @@ async function mockFetch<T>(url: string, opts?: RequestInit): Promise<T> {
     case /^\/programs\/[^/]+\/restore$/.test(url) && method === 'POST':
       return { restored: true } as any;
     case /^\/programs\/[^/]+\/templates(?:\?.*)?$/.test(url) && method === 'GET': {
-      const programId = url.split('/')[2]?.split('?')[0];
+      const urlObj = new URL(url, 'https://example.com');
+      const pathParts = urlObj.pathname.split('/');
+      const programId = pathParts[2] ?? '';
+      const organizationParam = urlObj.searchParams.get('organization');
+      const subUnitParam = urlObj.searchParams.get('sub_unit');
+      const includeDeleted = urlObj.searchParams.get('include_deleted') === 'true';
+      let data = seed.templates.filter(t => t.programId === programId);
+      if (!includeDeleted) {
+        data = data.filter(t => !t.deletedAt);
+      }
+      if (organizationParam) {
+        const normalizedOrg = organizationParam.trim().toLowerCase();
+        if (normalizedOrg) {
+          data = data.filter(
+            template => (template.organization ?? '').trim().toLowerCase() === normalizedOrg,
+          );
+        }
+      }
+      if (subUnitParam) {
+        const normalizedSub = subUnitParam.trim().toLowerCase();
+        if (normalizedSub) {
+          data = data.filter(template => (template.subUnit ?? '').trim().toLowerCase() === normalizedSub);
+        }
+      }
       return {
-        data: seed.templates.filter(t => t.programId === programId),
+        data,
       } as any;
     }
     case /^\/programs\/[^/]+\/templates$/.test(url) && method === 'POST': {
@@ -939,6 +1023,8 @@ export const seed = {
       category: 'Engineering',
       updatedAt: '2024-05-15',
       status: 'published',
+      organization: 'People Ops',
+      subUnit: 'New Hires',
     },
     {
       id: 't2',
@@ -947,6 +1033,19 @@ export const seed = {
       category: 'Operations',
       updatedAt: '2024-04-20',
       status: 'draft',
+      organization: 'People Ops',
+      subUnit: 'Leadership',
+    },
+    {
+      id: 't3',
+      programId: 'p1',
+      name: 'Onboarding Checklist',
+      category: 'General',
+      updatedAt: '2024-03-01',
+      status: 'deprecated',
+      deletedAt: '2024-06-01',
+      organization: 'People Ops',
+      subUnit: 'New Hires',
     },
   ] as Template[],
   audit: [


### PR DESCRIPTION
## Summary
- allow program-template queries to select and filter by organization and sub-unit data
- expose organization/sub-unit metadata through the API and template mocks
- add template-level filter controls and display organization context in the programs landing page

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d1ba6cb4a0832cbebada7bc0d08f58