### PR TITLE
Allow trainees to update own task journal entries

### DIFF
--- a/__tests__/taskRoutesAuth.test.js
+++ b/__tests__/taskRoutesAuth.test.js
@@ -263,6 +263,8 @@ describe('task routes authorization', () => {
     await traineeAgent.post('/auth/local/login').send({ username:'trainee', password:'passpass'}).expect(200);
     await traineeAgent.patch(`/tasks/${taskId}`).send({ label:'new' }).expect(403);
     await traineeAgent.patch(`/tasks/${taskId}`).send({ done:true }).expect(200);
+    const journalRes = await traineeAgent.patch(`/tasks/${taskId}`).send({ journal_entry: 'my notes' }).expect(200);
+    expect(journalRes.body.journal_entry).toBe('my notes');
 
     const mgrAgent = request.agent(app);
     await mgrAgent.post('/auth/local/login').send({ username:'mgr', password:'passpass'}).expect(200);

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -2589,7 +2589,7 @@ app.patch('/tasks/:id', ensurePerm('task.update', 'task.assign'), async (req, re
         allowed = allFields;
       }
     } else if (isTrainee && owns) {
-      allowed = ['done'];
+      allowed = ['done', 'journal_entry'];
     } else {
       return res.status(403).json({ error: 'forbidden' });
     }


### PR DESCRIPTION
## Summary
- allow task-owning trainees to patch their journal entries while keeping other fields restricted
- extend task route authorization test to cover trainee journal entry updates and ensure blocked fields remain forbidden

## Testing
- npm test -- taskRoutesAuth

------
https://chatgpt.com/codex/tasks/task_e_68d1c1fe25ec832c9c87a14914e55404