### PR TITLE
Add shared field options and update organization filters

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   testEnvironment: 'node',
   transform: {
-    '^.+\\.(ts|tsx)$': '<rootDir>/test-utils/esbuild-jest-transform.js',
+    '^.+\\.[tj]sx?$': '<rootDir>/test-utils/esbuild-jest-transform.js',
   },
   moduleNameMapper: {
     '^react$': '<rootDir>/test-utils/reactStub.js',

--- a/shared/field-options.d.ts
+++ b/shared/field-options.d.ts
@@ -1,0 +1,5 @@
+export declare const ORGANIZATION_OPTIONS: readonly string[];
+export declare const SUB_UNIT_OPTIONS: readonly string[];
+export declare const DISCIPLINE_TYPE_OPTIONS: readonly string[];
+export declare const DELIVERY_TYPE_OPTIONS: readonly string[];
+export declare const DEPARTMENT_OPTIONS: readonly string[];

--- a/shared/field-options.js
+++ b/shared/field-options.js
@@ -1,0 +1,29 @@
+export const ORGANIZATION_OPTIONS = Object.freeze([
+  'People Ops',
+  'Corporate',
+  'Retail',
+]);
+
+export const SUB_UNIT_OPTIONS = Object.freeze([
+  'New Hires',
+  'Leadership',
+  'Store Operations',
+]);
+
+export const DISCIPLINE_TYPE_OPTIONS = Object.freeze([
+  'Technical',
+  'Customer Service',
+  'Operations',
+]);
+
+export const DELIVERY_TYPE_OPTIONS = Object.freeze([
+  'In person',
+  'Virtual',
+  'Self-paced',
+]);
+
+export const DEPARTMENT_OPTIONS = Object.freeze([
+  'Engineering',
+  'Retail',
+  'People Ops',
+]);

--- a/src/programs/ProgramsLanding.tsx
+++ b/src/programs/ProgramsLanding.tsx
@@ -11,6 +11,7 @@ import {
   Program,
   Template,
 } from '../api';
+import { ORGANIZATION_OPTIONS, SUB_UNIT_OPTIONS } from '../../shared/field-options.js';
 import { can, User } from '../rbac';
 
 type TabKey = 'programs' | 'templates' | 'assignments';
@@ -64,8 +65,8 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
   const refreshPrograms = useCallback(async () => {
     const response = await getPrograms({
       query: searchQuery,
-      organization: organizationFilter,
-      subUnit: subUnitFilter,
+      organization: organizationFilter || undefined,
+      subUnit: subUnitFilter || undefined,
     });
     setPrograms(response.data);
     setSelectedProgramId(prev => {
@@ -84,25 +85,19 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
         setTemplates([]);
         return [] as Template[];
       }
-      const trimmedOrganization = templateOrganizationFilter.trim();
-      const trimmedSubUnit = templateSubUnitFilter.trim();
+      const organization = templateOrganizationFilter || undefined;
+      const subUnit = templateSubUnitFilter || undefined;
       const response = await getProgramTemplates(targetProgramId, {
         includeDeleted: true,
-        organization: trimmedOrganization || undefined,
-        subUnit: trimmedSubUnit || undefined,
+        organization,
+        subUnit,
       });
       let filtered = response.data;
-      if (trimmedOrganization) {
-        const normalizedOrg = trimmedOrganization.toLowerCase();
-        filtered = filtered.filter(
-          template => (template.organization ?? '').trim().toLowerCase() === normalizedOrg,
-        );
+      if (organization) {
+        filtered = filtered.filter(template => (template.organization ?? '') === organization);
       }
-      if (trimmedSubUnit) {
-        const normalizedSub = trimmedSubUnit.toLowerCase();
-        filtered = filtered.filter(
-          template => (template.subUnit ?? '').trim().toLowerCase() === normalizedSub,
-        );
+      if (subUnit) {
+        filtered = filtered.filter(template => (template.subUnit ?? '') === subUnit);
       }
       setTemplates(filtered);
       return response.data;
@@ -308,27 +303,37 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
                 <label htmlFor="program-organization" className="text-[var(--text-muted)]">
                   Organization
                 </label>
-                <input
+                <select
                   id="program-organization"
                   className="form-field"
-                  placeholder="e.g. People Ops"
                   value={organizationFilter}
                   onChange={event => setOrganizationFilter(event.target.value)}
-                  onBlur={event => setOrganizationFilter(event.target.value.trim())}
-                />
+                >
+                  <option value="">All organizations</option>
+                  {ORGANIZATION_OPTIONS.map(option => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
               </div>
               <div className="flex flex-col gap-1 text-sm">
                 <label htmlFor="program-sub-unit" className="text-[var(--text-muted)]">
                   Sub-unit
                 </label>
-                <input
+                <select
                   id="program-sub-unit"
                   className="form-field"
-                  placeholder="e.g. New Hire Experience"
                   value={subUnitFilter}
                   onChange={event => setSubUnitFilter(event.target.value)}
-                  onBlur={event => setSubUnitFilter(event.target.value.trim())}
-                />
+                >
+                  <option value="">All sub-units</option>
+                  {SUB_UNIT_OPTIONS.map(option => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
               </div>
             </div>
             {can(currentUser, 'create', 'program') && (
@@ -457,29 +462,39 @@ export default function ProgramsLanding({ currentUser }: { currentUser: User }) 
                 <label htmlFor="template-organization-filter" className="text-[var(--text-muted)]">
                   Organization
                 </label>
-                <input
+                <select
                   id="template-organization-filter"
                   className="form-field"
-                  placeholder="e.g. People Ops"
                   value={templateOrganizationFilter}
                   onChange={event => setTemplateOrganizationFilter(event.target.value)}
-                  onBlur={event => setTemplateOrganizationFilter(event.target.value.trim())}
                   disabled={!selectedProgramId}
-                />
+                >
+                  <option value="">All organizations</option>
+                  {ORGANIZATION_OPTIONS.map(option => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
               </div>
               <div className="flex flex-col gap-1 text-sm">
                 <label htmlFor="template-sub-unit-filter" className="text-[var(--text-muted)]">
                   Sub-unit
                 </label>
-                <input
+                <select
                   id="template-sub-unit-filter"
                   className="form-field"
-                  placeholder="e.g. New Hire Experience"
                   value={templateSubUnitFilter}
                   onChange={event => setTemplateSubUnitFilter(event.target.value)}
-                  onBlur={event => setTemplateSubUnitFilter(event.target.value.trim())}
                   disabled={!selectedProgramId}
-                />
+                >
+                  <option value="">All sub-units</option>
+                  {SUB_UNIT_OPTIONS.map(option => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
               </div>
             </div>
           </div>

--- a/src/users/EditUserModal.tsx
+++ b/src/users/EditUserModal.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, useEffect, useState } from 'react';
+import { ORGANIZATION_OPTIONS } from '../../shared/field-options.js';
 import { User } from '../rbac';
 import UserModal from './UserModal';
 
@@ -88,12 +89,18 @@ export default function EditUserModal({ open, user, onClose, onSave }: EditUserM
           <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">
             Organization
           </label>
-          <input
+          <select
             className="w-full border border-[var(--border)] rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
             value={organization}
             onChange={event => setOrganization(event.target.value)}
-            placeholder="Acme Corp"
-          />
+          >
+            <option value="">Select an organization</option>
+            {ORGANIZATION_OPTIONS.map(option => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
         </div>
         <div className="space-y-1">
           <label className="block text-xs font-semibold uppercase tracking-wide text-[var(--text-muted)]">


### PR DESCRIPTION
## Summary
- add a shared field options module that exports organization-related dropdown values
- replace organization text inputs with shared select controls in the user modal and programs landing filters
- update Jest configuration so JavaScript modules are transformed during tests

## Testing
- npm test -- --runTestsByPath __tests__/usersAssignPrograms.test.tsx
- npm test -- --runTestsByPath __tests__/usersLandingPermissions.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68d1d86f79e4832ca13ee6f16d94fdeb