### PR TITLE
Use shared dropdowns in admin program template and user managers

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -724,26 +724,36 @@
           <div class="grid gap-3 md:grid-cols-2">
             <label class="space-y-1">
               <span class="label-text">Organization</span>
-              <input id="templateFormOrganization" name="organization" class="input" placeholder="e.g. Onboarding Ops">
+              <select id="templateFormOrganization" name="organization" class="input">
+                <option value="">None</option>
+              </select>
             </label>
             <label class="space-y-1">
               <span class="label-text">Sub-unit</span>
-              <input id="templateFormSubUnit" name="sub_unit" class="input" placeholder="e.g. New Hire Experience">
+              <select id="templateFormSubUnit" name="sub_unit" class="input">
+                <option value="">None</option>
+              </select>
             </label>
           </div>
           <div class="grid gap-3 md:grid-cols-2">
             <label class="space-y-1">
               <span class="label-text">Discipline type</span>
-              <input id="templateFormDisciplineType" name="discipline_type" class="input" placeholder="e.g. Technical">
+              <select id="templateFormDisciplineType" name="discipline_type" class="input">
+                <option value="">None</option>
+              </select>
             </label>
             <label class="space-y-1">
               <span class="label-text">Delivery type</span>
-              <input id="templateFormDeliveryType" name="type_delivery" class="input" placeholder="e.g. In person">
+              <select id="templateFormDeliveryType" name="type_delivery" class="input">
+                <option value="">None</option>
+              </select>
             </label>
           </div>
           <label class="space-y-1">
             <span class="label-text">Department</span>
-            <input id="templateFormDepartment" name="department" class="input" placeholder="e.g. Research &amp; Development">
+            <select id="templateFormDepartment" name="department" class="input">
+              <option value="">None</option>
+            </select>
           </label>
           <div>
             <label for="templateFormNotes" class="label-text mb-1">Notes</label>

--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -1,3 +1,11 @@
+import {
+  DISCIPLINE_TYPE_OPTIONS,
+  DELIVERY_TYPE_OPTIONS,
+  DEPARTMENT_OPTIONS,
+  ORGANIZATION_OPTIONS,
+  SUB_UNIT_OPTIONS,
+} from '../../shared/field-options.js';
+
 const API = window.location.origin;
 const TEMPLATE_API = `${API}/api/templates`;
 
@@ -64,6 +72,42 @@ const HTML_ESCAPE_REGEXP = /[&<>"']/g;
 function escapeHtml(value) {
   if (value === null || value === undefined) return '';
   return String(value).replace(HTML_ESCAPE_REGEXP, match => HTML_ESCAPE_LOOKUP[match] || match);
+}
+
+function populateSelectOptions(selectElement, options) {
+  if (!(selectElement instanceof HTMLSelectElement) || !Array.isArray(options)) {
+    return;
+  }
+  const existingValues = new Set(Array.from(selectElement.options, option => option.value));
+  options.forEach(optionValue => {
+    if (!optionValue || existingValues.has(optionValue)) {
+      return;
+    }
+    const option = document.createElement('option');
+    option.value = optionValue;
+    option.textContent = optionValue;
+    selectElement.appendChild(option);
+    existingValues.add(optionValue);
+  });
+}
+
+function ensureSelectValue(selectElement, value) {
+  if (!(selectElement instanceof HTMLSelectElement)) {
+    return;
+  }
+  if (value === null || value === undefined || value === '') {
+    selectElement.value = '';
+    return;
+  }
+  const stringValue = String(value);
+  const hasOption = Array.from(selectElement.options).some(option => option.value === stringValue);
+  if (!hasOption) {
+    const option = document.createElement('option');
+    option.value = stringValue;
+    option.textContent = stringValue;
+    selectElement.appendChild(option);
+  }
+  selectElement.value = stringValue;
 }
 
 let toastContainerElement = null;
@@ -1376,6 +1420,12 @@ const templatePager = document.getElementById('tmplPager');
 const templatePagerLabel = document.getElementById('tmplPagerLabel');
 const templatePagerPrev = document.getElementById('tmplPagerPrev');
 const templatePagerNext = document.getElementById('tmplPagerNext');
+
+populateSelectOptions(templateFormOrganizationInput, ORGANIZATION_OPTIONS);
+populateSelectOptions(templateFormSubUnitInput, SUB_UNIT_OPTIONS);
+populateSelectOptions(templateFormDisciplineTypeInput, DISCIPLINE_TYPE_OPTIONS);
+populateSelectOptions(templateFormDeliveryTypeInput, DELIVERY_TYPE_OPTIONS);
+populateSelectOptions(templateFormDepartmentInput, DEPARTMENT_OPTIONS);
 
 if (!programTableBody || !templateTableBody || !programActionsContainer || !templateActionsContainer) {
   throw new Error('Program & Template Manager: required DOM nodes are missing.');
@@ -4044,11 +4094,11 @@ function openTemplateModal(mode = 'create', templateId = null) {
     }
     if (templateFormOrganizationInput) {
       const organization = template?.organization ?? template?.org ?? '';
-      templateFormOrganizationInput.value = organization || '';
+      ensureSelectValue(templateFormOrganizationInput, organization);
     }
     if (templateFormSubUnitInput) {
       const subUnit = template?.sub_unit ?? template?.subUnit ?? '';
-      templateFormSubUnitInput.value = subUnit || '';
+      ensureSelectValue(templateFormSubUnitInput, subUnit);
     }
     if (templateFormDisciplineTypeInput) {
       const disciplineType = template?.discipline_type
@@ -4058,7 +4108,7 @@ function openTemplateModal(mode = 'create', templateId = null) {
         ?? template?.template?.disciplineType
         ?? template?.template?.discipline
         ?? '';
-      templateFormDisciplineTypeInput.value = disciplineType || '';
+      ensureSelectValue(templateFormDisciplineTypeInput, disciplineType);
     }
     if (templateFormDeliveryTypeInput) {
       const deliveryType = template?.type_delivery
@@ -4070,7 +4120,7 @@ function openTemplateModal(mode = 'create', templateId = null) {
         ?? template?.template?.delivery_type
         ?? template?.template?.deliveryType
         ?? '';
-      templateFormDeliveryTypeInput.value = deliveryType || '';
+      ensureSelectValue(templateFormDeliveryTypeInput, deliveryType);
     }
     if (templateFormDepartmentInput) {
       const department = template?.department
@@ -4078,7 +4128,7 @@ function openTemplateModal(mode = 'create', templateId = null) {
         ?? template?.template?.department
         ?? template?.template?.dept
         ?? '';
-      templateFormDepartmentInput.value = department || '';
+      ensureSelectValue(templateFormDepartmentInput, department);
     }
     if (templateFormNotesInput) {
       const notes = template?.notes ?? '';
@@ -4250,31 +4300,11 @@ async function submitTemplateForm(event) {
     templateFormLabelInput?.focus();
     return;
   }
-  const organizationRawValue = templateFormOrganizationInput?.value ?? '';
-  const organizationValue = organizationRawValue.trim();
-  if (templateFormOrganizationInput) {
-    templateFormOrganizationInput.value = organizationValue;
-  }
-  const subUnitRawValue = templateFormSubUnitInput?.value ?? '';
-  const subUnitValue = subUnitRawValue.trim();
-  if (templateFormSubUnitInput) {
-    templateFormSubUnitInput.value = subUnitValue;
-  }
-  const disciplineTypeRawValue = templateFormDisciplineTypeInput?.value ?? '';
-  const disciplineTypeValue = disciplineTypeRawValue.trim();
-  if (templateFormDisciplineTypeInput) {
-    templateFormDisciplineTypeInput.value = disciplineTypeValue;
-  }
-  const deliveryTypeRawValue = templateFormDeliveryTypeInput?.value ?? '';
-  const deliveryTypeValue = deliveryTypeRawValue.trim();
-  if (templateFormDeliveryTypeInput) {
-    templateFormDeliveryTypeInput.value = deliveryTypeValue;
-  }
-  const departmentRawValue = templateFormDepartmentInput?.value ?? '';
-  const departmentValue = departmentRawValue.trim();
-  if (templateFormDepartmentInput) {
-    templateFormDepartmentInput.value = departmentValue;
-  }
+  const organizationValue = templateFormOrganizationInput?.value ?? '';
+  const subUnitValue = templateFormSubUnitInput?.value ?? '';
+  const disciplineTypeValue = templateFormDisciplineTypeInput?.value ?? '';
+  const deliveryTypeValue = templateFormDeliveryTypeInput?.value ?? '';
+  const departmentValue = templateFormDepartmentInput?.value ?? '';
   const sortRawValue = templateFormSortInput?.value ?? '';
   let sortNumber = null;
   if (sortRawValue !== '') {

--- a/public/admin/user-manager.html
+++ b/public/admin/user-manager.html
@@ -408,7 +408,9 @@
         </div>
         <div>
           <label class="block text-sm mb-1" for="editOrganization">Organization</label>
-          <input id="editOrganization" name="organization" class="w-full border rounded-xl px-3 py-2 text-sm" placeholder="Organization">
+          <select id="editOrganization" name="organization" class="w-full border rounded-xl px-3 py-2 text-sm">
+            <option value="">None</option>
+          </select>
         </div>
         <div>
           <label class="block text-sm mb-1" for="editEmail">Email</label>
@@ -492,11 +494,49 @@
   </div>
 
   <script type="module">
+import { ORGANIZATION_OPTIONS } from '../../shared/field-options.js';
+
 const API = window.location.origin;
 
 const HTML_ESCAPES = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
 function escapeHtml(value = '') {
   return String(value).replace(/[&<>"']/g, ch => HTML_ESCAPES[ch] || ch);
+}
+
+function populateSelectOptions(selectElement, options) {
+  if (!(selectElement instanceof HTMLSelectElement) || !Array.isArray(options)) {
+    return;
+  }
+  const existingValues = new Set(Array.from(selectElement.options, option => option.value));
+  options.forEach(optionValue => {
+    if (!optionValue || existingValues.has(optionValue)) {
+      return;
+    }
+    const option = document.createElement('option');
+    option.value = optionValue;
+    option.textContent = optionValue;
+    selectElement.appendChild(option);
+    existingValues.add(optionValue);
+  });
+}
+
+function ensureSelectValue(selectElement, value) {
+  if (!(selectElement instanceof HTMLSelectElement)) {
+    return;
+  }
+  if (value === null || value === undefined || value === '') {
+    selectElement.value = '';
+    return;
+  }
+  const stringValue = String(value);
+  const hasOption = Array.from(selectElement.options).some(option => option.value === stringValue);
+  if (!hasOption) {
+    const option = document.createElement('option');
+    option.value = stringValue;
+    option.textContent = stringValue;
+    selectElement.appendChild(option);
+  }
+  selectElement.value = stringValue;
 }
 
 const meRes = await fetch(`${API}/me`, { credentials: 'include' });
@@ -616,6 +656,8 @@ const inputEditEmail = document.getElementById('editEmail');
 const inputCreateRoles = document.getElementById('createRoles');
 const textareaDeactivateReason = document.getElementById('deactivateReason');
 
+populateSelectOptions(inputEditOrganization, ORGANIZATION_OPTIONS);
+
 const btnDeactivate = document.getElementById('btnDeactivate');
 const btnReactivate = document.getElementById('btnReactivate');
 const btnArchive = document.getElementById('btnArchive');
@@ -728,7 +770,7 @@ function renderSelectedUser(user) {
   programsUserName.textContent = displayName;
   lifecycleUserName.textContent = displayName;
   if (inputEditFullName) inputEditFullName.value = user.full_name || '';
-  if (inputEditOrganization) inputEditOrganization.value = user.organization || '';
+  if (inputEditOrganization) ensureSelectValue(inputEditOrganization, user.organization || '');
   if (inputEditEmail) inputEditEmail.value = user.username || '';
   setUserActionState(true);
   setLifecycleButtons(status);
@@ -857,7 +899,7 @@ formEdit.addEventListener('submit', async e => {
     full_name: (formData.get('fullName') || '').toString().trim(),
     email: (formData.get('email') || '').toString().trim(),
     organization: (() => {
-      const value = (formData.get('organization') || '').toString().trim();
+      const value = (formData.get('organization') || '').toString();
       return value ? value : null;
     })()
   };


### PR DESCRIPTION
## Summary
- replace program template metadata inputs with shared select dropdowns populated from common option lists
- load the shared organization list in the user manager edit drawer and handle the select value consistently in form logic
- ensure template editing respects existing values that may not appear in the default option lists

## Testing
- Not run (manual verification required but not possible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1dbbc3d3c832cadb451c4d1db638d