### PR TITLE
Serve shared assets from orientation server

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -111,6 +111,8 @@ const PUBLIC_DIR = path.join(__dirname, 'public');
 app.use(express.static(PUBLIC_DIR));
 const SRC_DIR = path.join(__dirname, 'src');
 app.use('/src', express.static(SRC_DIR));
+const SHARED_DIR = path.join(__dirname, 'shared');
+app.use('/shared', express.static(SHARED_DIR));
 app.get('/', (_req, res) => {
   res.sendFile(path.join(PUBLIC_DIR, 'orientation_index.html'));
 });


### PR DESCRIPTION
## Summary
- expose the shared assets directory alongside existing static routes in the orientation server

## Testing
- manual verification: started the orientation server and requested http://127.0.0.1:3002/shared/field-options.js

------
https://chatgpt.com/codex/tasks/task_e_68d1ef27c2d0832c962894c97b60feba