### PR TITLE
Preserve trainee selection when loading privileged user list

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -1125,9 +1125,11 @@ function App({ me, onSignOut }){
 
   useEffect(() => {
     if (!isPrivileged) return;
+    let isCancelled = false;
     (async () => {
       try {
         const list = await apiListUsers();
+        if (isCancelled) return;
         let normalized = Array.isArray(list) ? [...list] : [];
         if (CURRENT_USER_ID) {
           const hasCurrent = normalized.some(u => sameId(u.id, CURRENT_USER_ID));
@@ -1139,14 +1141,38 @@ function App({ me, onSignOut }){
             ];
           }
         }
+
+        const stored = readStoredTrainee();
+        let preferredTargetId = TARGET_USER_ID || (stored?.id ? String(stored.id) : null);
+        let preferredTargetName = TARGET_USER_NAME || stored?.name || '';
+
+        if (!preferredTargetId && CURRENT_USER_ID) {
+          preferredTargetId = String(CURRENT_USER_ID);
+          if (!preferredTargetName) {
+            preferredTargetName = me?.name || me?.full_name || me?.username || 'Current user';
+          }
+        }
+
+        if (preferredTargetId && !normalized.some(u => sameId(u.id, preferredTargetId))) {
+          const fallbackName = preferredTargetName || 'Selected trainee';
+          normalized = [
+            ...normalized,
+            { id: preferredTargetId, full_name: fallbackName, name: fallbackName },
+          ];
+        }
+
         setUserList(normalized);
-        if (CURRENT_USER_ID) {
-          setTargetUserId(String(CURRENT_USER_ID));
+
+        if (!TARGET_USER_ID && preferredTargetId) {
+          setTargetUserId(String(preferredTargetId));
         }
       } catch (err) {
         console.error('Failed to load users', err);
       }
     })();
+    return () => {
+      isCancelled = true;
+    };
   }, [isPrivileged, me]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- preserve the stored trainee selection when refreshing the privileged user list
- ensure the current user is still injected if missing without overriding the preferred trainee
- add a cancellation guard to the privileged user list fetch effect

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1fda6203c832c8637c808824298db