### PR TITLE
Hide privileged user selection dropdown

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -3070,7 +3070,7 @@ useEffect(() => {
         </div>
         <div className="pt-4 space-y-4">
           {isPrivileged && (
-            <div>
+            <div className="sr-only">
               <label htmlFor="target-user" className="sr-only">Viewing tasks for</label>
               <select
                 id="target-user"


### PR DESCRIPTION
## Summary
- visually hide the privileged user selection dropdown while keeping it in the DOM for programmatic access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d207fadaa0832cafc6f84384d4bec5