### PR TITLE
Add external link column to orientation tasks bootstrap

### DIFF
--- a/__tests__/programRoutes.test.js
+++ b/__tests__/programRoutes.test.js
@@ -132,7 +132,8 @@ describe('program routes', () => {
         notes text,
         journal_entry text,
         responsible_person text,
-        deleted boolean default false
+        deleted boolean default false,
+        external_link text
       );
       insert into public.roles(role_key) values ('admin'),('manager'),('viewer'),('trainee'),('auditor');
     `);

--- a/__tests__/rbacRoutes.test.js
+++ b/__tests__/rbacRoutes.test.js
@@ -70,7 +70,8 @@ describe('rbac admin routes', () => {
         notes text,
         journal_entry text,
         responsible_person text,
-        deleted boolean default false
+        deleted boolean default false,
+        external_link text
       );
       insert into public.roles(role_key) values ('admin'),('manager'),('viewer'),('trainee'),('auditor');
     `);

--- a/__tests__/taskRoutesAuth.test.js
+++ b/__tests__/taskRoutesAuth.test.js
@@ -56,7 +56,8 @@ describe('task routes authorization', () => {
         notes text,
         journal_entry text,
         responsible_person text,
-        deleted boolean default false
+        deleted boolean default false,
+        external_link text
       );
       create table public.user_roles (
         user_id uuid,

--- a/migrations/016_add_external_link_to_orientation_tasks.sql
+++ b/migrations/016_add_external_link_to_orientation_tasks.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.orientation_tasks ADD COLUMN IF NOT EXISTS external_link text;


### PR DESCRIPTION
## Summary
- add a migration that ensures orientation_tasks has an external_link column
- update pg-mem bootstrap schemas used in program, task auth, and RBAC route tests to include the new column

## Testing
- CI=true npm test -- --runTestsByPath __tests__/programRoutes.test.js __tests__/taskRoutesAuth.test.js __tests__/rbacRoutes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d23730ce94832ca322be5da1b0469e