### PR TITLE
Add delivery type column to template manager

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -542,6 +542,15 @@
                         </span>
                       </button>
                     </th>
+                    <th data-key="deliveryType" data-type="string" aria-sort="none">
+                      <button type="button" class="sort-trigger">
+                        <span>Delivery type</span>
+                        <span class="sort-indicator" data-sort-indicator aria-hidden="true">
+                          <span class="sort-arrow sort-arrow-asc">▲</span>
+                          <span class="sort-arrow sort-arrow-desc">▼</span>
+                        </span>
+                      </button>
+                    </th>
                     <th data-key="auditInserted" data-type="date" aria-sort="none">
                       <button type="button" class="sort-trigger">
                         <span>Inserted By (Audit)</span>

--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -899,6 +899,7 @@ const PROGRAM_SORT_ACCESSORS = {
 const TEMPLATE_SORT_ACCESSORS = {
   week: getTemplateWeekNumber,
   name: getTemplateName,
+  deliveryType: getTemplateDeliveryType,
   auditInserted: getTemplateAuditSortValue,
   status: template => normalizeTemplateStatusValue(getTemplateStatus(template)),
   updatedAt: getTemplateUpdatedAt,
@@ -5226,13 +5227,14 @@ function renderTemplates() {
   };
   const displayed = currentTemplatePageItems;
   if (!displayed.length) {
-    templateTableBody.innerHTML = '<tr class="empty-row"><td colspan="7">No templates found.</td></tr>';
+    templateTableBody.innerHTML = '<tr class="empty-row"><td colspan="8">No templates found.</td></tr>';
   } else {
     templateTableBody.innerHTML = displayed.map(template => {
       const templateId = getTemplateId(template);
       const disabledAttr = CAN_MANAGE_TEMPLATES ? '' : 'disabled';
       const checkedAttr = templateId && selectedTemplateIds.has(templateId) ? 'checked' : '';
       const name = getTemplateName(template) || '—';
+      const deliveryType = getTemplateDeliveryType(template) || '—';
       const status = getTemplateStatus(template);
       const isArchived = normalizeTemplateStatusValue(status) === 'archived';
       const updatedAt = getTemplateUpdatedAt(template);
@@ -5259,6 +5261,7 @@ function renderTemplates() {
           <td><input type="checkbox" data-template-id="${templateId ?? ''}" ${checkedAttr} ${disabledAttr} class="rounded border-slate-300"></td>
           <td>${weekNumber ?? '—'}</td>
           <td class="font-medium">${name}</td>
+          <td>${escapeHtml(deliveryType)}</td>
           <td${auditSortAttr}>${escapeHtml(auditDisplay)}</td>
           <td>${createStatusBadge(status)}</td>
           <td>${formatDate(updatedAt)}</td>


### PR DESCRIPTION
## Summary
- add a Delivery type column to the template manager table header
- render each template row with its delivery type and keep empty-state colspan aligned
- wire template sorting accessors to support the new delivery type column

## Testing
- no automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2c8fc2238832c936a1b8445434c26