### PR TITLE
Add type_delivery support for program links and tasks

### DIFF
--- a/__tests__/rbacRoutes.test.js
+++ b/__tests__/rbacRoutes.test.js
@@ -72,7 +72,8 @@ describe('rbac admin routes', () => {
         journal_entry text,
         responsible_person text,
         deleted boolean default false,
-        external_link text
+        external_link text,
+        type_delivery text
       );
       insert into public.roles(role_key) values ('admin'),('manager'),('viewer'),('trainee'),('auditor');
     `);

--- a/__tests__/taskRoutesAuth.test.js
+++ b/__tests__/taskRoutesAuth.test.js
@@ -58,7 +58,8 @@ describe('task routes authorization', () => {
         journal_entry text,
         responsible_person text,
         deleted boolean default false,
-        external_link text
+        external_link text,
+        type_delivery text
       );
       create table public.user_roles (
         user_id uuid,

--- a/__tests__/templateApi.test.js
+++ b/__tests__/templateApi.test.js
@@ -33,6 +33,11 @@ const addExternalLinkMigration = fs.readFileSync(
   'utf-8'
 );
 
+const addTypeDeliveryMigration = fs.readFileSync(
+  path.join(__dirname, '..', 'migrations', '019_add_type_delivery_to_links_and_tasks.sql'),
+  'utf-8'
+);
+
 const DEFAULT_PASSWORD = 'passpass';
 
 describe('template api', () => {
@@ -98,6 +103,8 @@ describe('template api', () => {
         visibility text,
         visible boolean default true,
         notes text,
+        external_link text,
+        type_delivery text,
         created_by uuid,
         updated_by uuid,
         created_at timestamptz not null default now(),
@@ -117,9 +124,16 @@ describe('template api', () => {
         program_id text,
         role text
       );
+      create table public.orientation_tasks (
+        task_id uuid primary key default gen_random_uuid(),
+        user_id uuid,
+        label text,
+        type_delivery text
+      );
       insert into public.roles(role_key) values ('admin'), ('manager'), ('viewer'), ('trainee'), ('auditor');
     `);
     await pool.query(addExternalLinkMigration);
+    await pool.query(addTypeDeliveryMigration);
   });
 
   afterEach(async () => {

--- a/migrations/019_add_type_delivery_to_links_and_tasks.sql
+++ b/migrations/019_add_type_delivery_to_links_and_tasks.sql
@@ -1,0 +1,15 @@
+ALTER TABLE public.program_template_links
+  ADD COLUMN IF NOT EXISTS type_delivery text;
+
+ALTER TABLE public.orientation_tasks
+  ADD COLUMN IF NOT EXISTS type_delivery text;
+
+UPDATE public.program_template_links
+   SET type_delivery = t.type_delivery
+  FROM public.program_task_templates t
+ WHERE public.program_template_links.template_id = t.template_id
+   AND t.type_delivery IS NOT NULL
+   AND (
+     public.program_template_links.type_delivery IS NULL
+     OR public.program_template_links.type_delivery <> t.type_delivery
+   );

--- a/src/api.ts
+++ b/src/api.ts
@@ -28,6 +28,7 @@ export interface Template {
   subUnit: string | null;
   disciplineType: string | null;
   typeDelivery: string | null;
+  linkTypeDelivery?: string | null;
   department: string | null;
 }
 
@@ -400,6 +401,8 @@ const normalizeTemplate = (raw: any): Template => {
   }
 
   const deliverySource =
+    raw.linkTypeDelivery ??
+    raw.link_type_delivery ??
     raw.typeDelivery ??
     raw.type_delivery ??
     raw.deliveryType ??
@@ -412,6 +415,15 @@ const normalizeTemplate = (raw: any): Template => {
     typeDelivery = trimmed ? trimmed : null;
   } else if (deliverySource === null) {
     typeDelivery = null;
+  }
+
+  const linkDeliverySource = raw.linkTypeDelivery ?? raw.link_type_delivery ?? null;
+  let linkTypeDelivery: string | null | undefined;
+  if (typeof linkDeliverySource === 'string') {
+    const trimmed = linkDeliverySource.trim();
+    linkTypeDelivery = trimmed ? trimmed : null;
+  } else if (linkDeliverySource === null) {
+    linkTypeDelivery = null;
   }
 
   const departmentSource = raw.department ?? raw.dept ?? raw.departmentName ?? null;
@@ -437,6 +449,9 @@ const normalizeTemplate = (raw: any): Template => {
     typeDelivery,
     department,
   };
+  if (typeof linkTypeDelivery !== 'undefined') {
+    template.linkTypeDelivery = linkTypeDelivery;
+  }
   const parsedDate = toDateString(updatedCandidate);
   if (parsedDate) {
     template.updatedAt = parsedDate;


### PR DESCRIPTION
## Summary
- propagate `type_delivery` through program template link APIs and both self-serve and RBAC instantiation flows so orientation tasks capture the effective delivery type
- allow editing and persistence of link-level `type_delivery` via the program template links DAO, API serializer updates, and a migration that backfills data from templates
- extend client normalization and server tests to cover the new metadata end-to-end, including ensuring Assign Program keeps delivery type overrides

## Testing
- npx jest __tests__/programRoutes.test.js --runInBand
- npx jest __tests__/templateApi.test.js --runInBand
- npx jest __tests__/rbacRoutes.test.js --runInBand
- npx jest __tests__/taskRoutesAuth.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d2f9b899ac832c8ed751d8e1d4ebc0