### PR TITLE
Allow managers to bypass program access checks

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -762,6 +762,9 @@ async function ensureProgramManagementAccess(req, programId) {
   if (req.roles?.includes('admin')) {
     return true;
   }
+  if (req.roles?.includes('manager')) {
+    return true;
+  }
   const manages = await userManagesProgram(req.user?.id, programId);
   if (!manages) {
     throw createHttpError(403, 'forbidden');


### PR DESCRIPTION
## Summary
- update ensureProgramManagementAccess to bypass program-level restriction for managers similarly to admins

## Testing
- npm test -- program-template-manager.tagify.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d31c0a932c832c84aa796dbb642a4e