### PR TITLE
Prefer email for edit form

### DIFF
--- a/public/admin/user-manager.html
+++ b/public/admin/user-manager.html
@@ -966,7 +966,7 @@ function renderSelectedUser(user) {
   if (inputEditDepartment) ensureSelectValue(inputEditDepartment, user.department ?? '');
   if (inputEditDisciplineType) ensureSelectValue(inputEditDisciplineType, user.discipline_type ?? '');
   if (inputEditOrganization) ensureSelectValue(inputEditOrganization, user.organization ?? '');
-  if (inputEditEmail) inputEditEmail.value = user.username || '';
+  if (inputEditEmail) inputEditEmail.value = user.email || user.username || '';
   if (loadCalendarStatus) {
     loadCalendarStatus.textContent = '';
     loadCalendarStatus.classList.remove('text-emerald-600', 'text-rose-600');


### PR DESCRIPTION
## Summary
- prefer the selected user's email when pre-filling the edit form email input, falling back to username only when necessary

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d343983f54832c8ae589a3424da8b5