### PR TITLE
Derive template manager scope from role assignments

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -859,8 +859,11 @@ apiRouter.get('/templates', ensurePerm('template.read'), async (req, res) => {
       status = normalizedStatus;
     }
     const queryOrganization = typeof req.query?.organization === 'string' ? req.query.organization : undefined;
+    const roles = Array.isArray(req.roles) ? req.roles : [];
+    const isAdmin = roles.includes('admin') || req.user?.role === 'admin';
+    const isManager = roles.includes('manager') || req.user?.role === 'manager';
     let enforcedOrganization;
-    if (req.user?.role === 'manager') {
+    if (isManager && !isAdmin) {
       const rawOrganization = req.user?.organization_id
         ?? req.user?.organizationId
         ?? req.user?.organizationID


### PR DESCRIPTION
## Summary
- derive manager/admin flags for template listings from resolved roles
- continue enforcing organization scoping only for managers without admin rights
- add regression coverage for managers whose role is populated solely via user_roles

## Testing
- npm test -- templateApi

------
https://chatgpt.com/codex/tasks/task_e_68d343eef838832c8fb9463d5ddf7089