### PR TITLE
Handle missing edit email safely

### DIFF
--- a/public/admin/user-manager.html
+++ b/public/admin/user-manager.html
@@ -966,7 +966,11 @@ function renderSelectedUser(user) {
   if (inputEditDepartment) ensureSelectValue(inputEditDepartment, user.department ?? '');
   if (inputEditDisciplineType) ensureSelectValue(inputEditDisciplineType, user.discipline_type ?? '');
   if (inputEditOrganization) ensureSelectValue(inputEditOrganization, user.organization ?? '');
-  if (inputEditEmail) inputEditEmail.value = user.username || '';
+  if (inputEditEmail) {
+    const email = typeof user.email === 'string' ? user.email : undefined;
+    const username = typeof user.username === 'string' ? user.username : '';
+    inputEditEmail.value = email ?? username;
+  }
   if (loadCalendarStatus) {
     loadCalendarStatus.textContent = '';
     loadCalendarStatus.classList.remove('text-emerald-600', 'text-rose-600');


### PR DESCRIPTION
## Summary
- ensure the edit email input prefers a string email value and only falls back to username when no email is available

## Testing
- npm test -- --watch=false *(fails: existing syntax error in shared/field-options.js reported by esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_68d343983f54832c8ae589a3424da8b5