### PR TITLE
Add program import controls and shared parsing helpers

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -362,6 +362,8 @@
           </label>
           <button id="btnNewProgram" class="btn btn-primary text-sm">New Program</button>
           <button id="btnEditProgram" class="btn btn-outline text-sm" disabled>Edit Program</button>
+          <input id="inputImportPrograms" type="file" accept=".csv,application/json,.json,text/csv" class="sr-only" />
+          <button id="btnImportPrograms" class="btn btn-outline text-sm">Import Programs</button>
           <button id="exportCsv" class="btn btn-outline text-sm">Export CSV</button>
           <button id="btnRefreshPrograms" class="btn btn-outline text-sm">Refresh</button>
         </div>


### PR DESCRIPTION
## Summary
- add hidden file input and Import Programs button to the program actions header
- refactor import parsing utilities for reuse across program and template imports
- implement program import normalization, operation building, sequential requests, and UI wiring with permission handling

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d354c69abc832cae996c22866e3d93