### PR TITLE
Add results and purpose columns to program manager

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -438,6 +438,24 @@
                     </span>
                   </button>
                 </th>
+                <th data-key="results" data-type="string">
+                  <button type="button" class="sort-trigger">
+                    <span>Results</span>
+                    <span class="sort-indicator" data-sort-indicator aria-hidden="true">
+                      <span class="sort-arrow sort-arrow-asc">▲</span>
+                      <span class="sort-arrow sort-arrow-desc">▼</span>
+                    </span>
+                  </button>
+                </th>
+                <th data-key="purpose" data-type="string">
+                  <button type="button" class="sort-trigger">
+                    <span>Purpose</span>
+                    <span class="sort-indicator" data-sort-indicator aria-hidden="true">
+                      <span class="sort-arrow sort-arrow-asc">▲</span>
+                      <span class="sort-arrow sort-arrow-desc">▼</span>
+                    </span>
+                  </button>
+                </th>
                 <th data-key="createdAt" data-type="date">
                   <button type="button" class="sort-trigger">
                     <span>Created</span>

--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -1388,6 +1388,8 @@ const PROGRAM_SORT_ACCESSORS = {
   lifecycle: getProgramLifecycle,
   weeks: getProgramTotalWeeks,
   description: getProgramDescription,
+  results: getProgramResults,
+  purpose: getProgramPurpose,
   createdAt: getProgramCreatedAt,
   archivedAt: getProgramArchivedAt,
 };
@@ -3151,6 +3153,8 @@ function getFilteredPrograms(source = programs) {
       getProgramTitle(p),
       getProgramLifecycle(p),
       getProgramDescription(p),
+      getProgramResults(p),
+      getProgramPurpose(p),
       getProgramId(p),
     ];
     const totalWeeks = getProgramTotalWeeks(p);
@@ -5995,7 +5999,7 @@ function renderPrograms() {
   };
   const displayed = currentProgramPageItems;
   if (!displayed.length) {
-    programTableBody.innerHTML = '<tr class="empty-row"><td colspan="7">No programs found.</td></tr>';
+    programTableBody.innerHTML = '<tr class="empty-row"><td colspan="9">No programs found.</td></tr>';
   } else {
     programTableBody.innerHTML = displayed.map(program => {
       const programId = getProgramId(program);
@@ -6014,6 +6018,8 @@ function renderPrograms() {
       const totalWeeks = getProgramTotalWeeks(program);
       const createdAt = getProgramCreatedAt(program);
       const description = getProgramDescription(program) || '—';
+      const results = getProgramResults(program) || '—';
+      const purpose = getProgramPurpose(program) || '—';
       return `
         <tr ${rowAttrs.join(' ')}>
           <td><input type="checkbox" data-program-id="${programId ?? ''}" ${checkedAttr} ${disabledAttr} class="rounded border-slate-300"></td>
@@ -6021,6 +6027,8 @@ function renderPrograms() {
           <td>${createStatusBadge(lifecycle)}</td>
           <td>${Number.isFinite(totalWeeks) ? totalWeeks : '—'}</td>
           <td>${description}</td>
+          <td>${results}</td>
+          <td>${purpose}</td>
           <td>${formatDate(createdAt)}</td>
           <td class="text-right">${formatDate(archivedAt)}</td>
         </tr>


### PR DESCRIPTION
## Summary
- add Results and Purpose columns to the Programs list table with existing styling and sort controls
- surface program results and purpose values in the rendered rows and include them in table sorting and search helpers
- update empty state column span to match the expanded table layout

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d35dc4ae80832c845939bcf5bcee14