### PR TITLE
Add support for persisting program results and purpose

### DIFF
--- a/__tests__/programRoutes.test.js
+++ b/__tests__/programRoutes.test.js
@@ -63,6 +63,8 @@ describe('program routes', () => {
         title text not null,
         total_weeks int,
         description text,
+        results text,
+        purpose text,
         organization text,
         sub_unit text,
         created_by uuid,

--- a/__tests__/rbacRoutes.test.js
+++ b/__tests__/rbacRoutes.test.js
@@ -55,6 +55,15 @@ describe('rbac admin routes', () => {
       create table public.programs (
         program_id uuid primary key,
         title text,
+        total_weeks int,
+        description text,
+        results text,
+        purpose text,
+        organization text,
+        sub_unit text,
+        created_by uuid,
+        created_at timestamptz default now(),
+        deleted_at timestamp,
         deleted boolean default false
       );
       create table public.orientation_tasks (

--- a/__tests__/templateApi.test.js
+++ b/__tests__/templateApi.test.js
@@ -71,6 +71,8 @@ describe('template api', () => {
         title text not null,
         total_weeks int,
         description text,
+        results text,
+        purpose text,
         organization text,
         sub_unit text,
         created_by uuid,


### PR DESCRIPTION
## Summary
- include results and purpose columns in program queries and persistence logic
- ensure database schema and test fixtures define the new optional program fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d35fa9a48c832c99183cd270f560f7