### PR TITLE
Allow trainees to use side panel toggle

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -3217,7 +3217,6 @@ useEffect(() => {
           tabIndex={0}
         ></div>
       )}
-      {!isTrainee && (
       <button
         id="side-panel-toggle"
         onClick={togglePanel}
@@ -3237,7 +3236,6 @@ useEffect(() => {
           </svg>
         )}
       </button>
-      )}
       {/* SidePanel: container uses `card`; buttons use `btn`; fields use `input` for consistent styling */}
       {panelOpen && (
         <div


### PR DESCRIPTION
## Summary
- remove the trainee-only guard from the side panel toggle button so it renders for every role

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d37a764840832ca9d85108879e0d53