### PR TITLE
Allow all roles to adjust calendar range

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -2657,7 +2657,7 @@ useEffect(() => {
     );
   }
 
-  const controlBar = !isTrainee && (
+  const controlBar = (
     <div className="flex items-center gap-3">
       <label className="text-sm text-slate-600">Start</label>
       <input type="date" className="input w-[160px]" value={startDate} onChange={(e)=> handleStartDateInput(e.target.value)} />


### PR DESCRIPTION
## Summary
- remove the trainee-only guard around the calendar control bar in orientation_index
- ensure the start date and week count inputs render for every role so the calendar view can be adjusted universally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d37c0e10b8832ca088110cc302cd92