### PR TITLE
Avoid loading programs when none selected

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -1508,6 +1508,14 @@ function App({ me, onSignOut }){
 
 
   const updateUserPrograms = useCallback(async (programList, { signal } = {}) => {
+    const effectiveProgramId = activeProgramId || QS_PROGRAM_ID || null;
+    if (!effectiveProgramId) {
+      if (signal?.aborted) return;
+      setPrograms([]);
+      setUserPrograms([]);
+      return;
+    }
+
     try {
       const tasks = await apiGetTasks({ include_deleted: false });
       const taskList = Array.isArray(tasks) ? tasks : [];
@@ -1545,7 +1553,7 @@ function App({ me, onSignOut }){
       console.error('Failed to load user programs', err);
       setUserPrograms([]);
     }
-  }, [targetUserId, hiddenProgramIds]);
+  }, [activeProgramId, targetUserId, hiddenProgramIds]);
 
 
 /* Load tasks */


### PR DESCRIPTION
## Summary
- skip program/task fetches for the orientation dashboard when no program is selected for the user
- reset program state to empty when no selection exists to prevent unintended data display

## Testing
- npm test -- --runTestsByPath __tests__/orientationRange.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3f97d15b4832cbc2a8db1114fd5f7