### PR TITLE
Fix user update discipline column usage

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -1549,9 +1549,8 @@ app.patch('/api/users/:id', ensureAuth, async (req, res) => {
     { column: 'first_name', keys: ['first_name', 'firstName'] },
     { column: 'surname', keys: ['surname', 'surName', 'maiden_name', 'maidenName'] },
     { column: 'sub_unit', keys: ['sub_unit', 'subUnit'] },
-    { column: 'discipline', keys: ['discipline'] },
     { column: 'department', keys: ['department', 'department_name', 'departmentName'] },
-    { column: 'discipline_type', keys: ['discipline_type', 'disciplineType'] },
+    { column: 'discipline_type', keys: ['discipline', 'discipline_type', 'disciplineType'] },
   ];
   const additionalFieldUpdates = [];
   for (const config of additionalFieldConfigs) {
@@ -1631,7 +1630,6 @@ app.patch('/api/users/:id', ensureAuth, async (req, res) => {
          first_name,
          surname,
          sub_unit,
-         discipline,
          department,
          discipline_type
        from public.users
@@ -1654,9 +1652,9 @@ app.patch('/api/users/:id', ensureAuth, async (req, res) => {
       first_name: user.first_name ?? null,
       surname: user.surname ?? null,
       sub_unit: user.sub_unit ?? null,
-      discipline: user.discipline ?? null,
       department: user.department ?? null,
       discipline_type: user.discipline_type ?? null,
+      discipline: user.discipline_type ?? null,
       roles: roleRows.map(r => r.role_key),
     });
   } catch (err) {

--- a/public/admin/user-manager.html
+++ b/public/admin/user-manager.html
@@ -444,12 +444,6 @@
                     </select>
                 </div>
                 <div>
-                    <label class="block text-sm mb-1" for="editDiscipline">Discipline</label>
-                    <select id="editDiscipline" name="discipline" class="input">
-                        <option value="">None</option>
-                    </select>
-                </div>
-                <div>
                     <label class="block text-sm mb-1" for="editDepartment">Department</label>
                     <select id="editDepartment" name="department" class="input">
                         <option value="">None</option>
@@ -739,7 +733,7 @@ const USER_FIELD_ALIASES = {
   last_login_at: ['lastLoginAt'],
   organization: ['organization_name', 'organizationName'],
   status: ['state'],
-  discipline_type: ['disciplineType', 'discipline'],
+  discipline_type: ['disciplineType'],
   last_name: ['lastName'],
   surname: ['maiden_name', 'maidenName'],
   first_name: ['firstName'],
@@ -1807,7 +1801,6 @@ const inputEditLastName = document.getElementById('editLastName');
 const inputEditFirstName = document.getElementById('editFirstName');
 const inputEditSurname = document.getElementById('editSurname');
 const inputEditSubUnit = document.getElementById('editSubUnit');
-const inputEditDiscipline = document.getElementById('editDiscipline');
 const inputEditDepartment = document.getElementById('editDepartment');
 const inputEditDisciplineType = document.getElementById('editDisciplineType');
 const inputEditOrganization = document.getElementById('editOrganization');
@@ -1828,7 +1821,6 @@ const accessDrawerNotice = document.getElementById('accessDrawerNotice');
 
 populateSelectOptions(inputEditOrganization, ORGANIZATION_OPTIONS);
 populateSelectOptions(inputEditSubUnit, SUB_UNIT_OPTIONS);
-populateSelectOptions(inputEditDiscipline, DISCIPLINE_TYPE_OPTIONS);
 populateSelectOptions(inputEditDepartment, DEPARTMENT_OPTIONS);
 populateSelectOptions(inputEditDisciplineType, DISCIPLINE_TYPE_OPTIONS);
 
@@ -1896,9 +1888,6 @@ function mergeUserProfilePayload(baseUser, payload) {
   }
   if ('sub_unit' in payload) {
     merged.sub_unit = payload.sub_unit;
-  }
-  if ('discipline' in payload) {
-    merged.discipline = payload.discipline;
   }
   if ('department' in payload) {
     merged.department = payload.department;
@@ -2120,7 +2109,6 @@ function renderSelectedUser(user) {
     if (inputEditFirstName) inputEditFirstName.value = '';
     if (inputEditSurname) inputEditSurname.value = '';
     if (inputEditSubUnit) ensureSelectValue(inputEditSubUnit, '');
-    if (inputEditDiscipline) ensureSelectValue(inputEditDiscipline, '');
     if (inputEditDepartment) ensureSelectValue(inputEditDepartment, '');
     if (inputEditDisciplineType) ensureSelectValue(inputEditDisciplineType, '');
     if (inputEditOrganization) ensureSelectValue(inputEditOrganization, '');
@@ -2162,7 +2150,6 @@ function renderSelectedUser(user) {
   if (inputEditFirstName) inputEditFirstName.value = user.first_name || '';
   if (inputEditSurname) inputEditSurname.value = user.surname || '';
   if (inputEditSubUnit) ensureSelectValue(inputEditSubUnit, user.sub_unit ?? '');
-  if (inputEditDiscipline) ensureSelectValue(inputEditDiscipline, user.discipline ?? '');
   if (inputEditDepartment) ensureSelectValue(inputEditDepartment, user.department ?? '');
   if (inputEditDisciplineType) ensureSelectValue(inputEditDisciplineType, user.discipline_type ?? '');
   if (inputEditOrganization) ensureSelectValue(inputEditOrganization, user.organization ?? '');
@@ -2554,7 +2541,6 @@ formEdit.addEventListener('submit', async e => {
     first_name: getNullableField('firstName'),
     surname: getNullableField('surname'),
     sub_unit: getNullableField('subUnit'),
-    discipline: getNullableField('discipline'),
     department: getNullableField('department'),
     discipline_type: getNullableField('disciplineType')
   };


### PR DESCRIPTION
## Summary
- treat legacy `discipline` payloads as aliases for `discipline_type` when updating a user
- stop issuing SQL updates and selects for the removed `discipline` column while still returning a `discipline` field derived from `discipline_type`

## Testing
- npm test -- --runTestsByPath __tests__/rbacRoutes.test.js *(fails: Transform failed with 1 error: Unexpected "===" in existing orientation_server.js markers)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f885d2ec832cbb172dc33bfd27c6