### PR TITLE
Hide schedule sections when no assignments

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -736,7 +736,8 @@ async function apiListUsers(){
 
 /* ---- Program & Template helpers ---- */
 async function apiListPrograms(){
-  const r = await fetch(`${API}/programs`, { credentials:'include' });
+  const url = withUser(`${API}/programs`);
+  const r = await fetch(url, { credentials:'include' });
   if(!r.ok) throw new Error('GET /programs failed');
   return r.json();
 }
@@ -944,7 +945,13 @@ function App({ me, onSignOut }){
   const [targetUserId, setTargetUserId] = useState(TARGET_USER_ID);
   const [targetUserName, setTargetUserName] = useState(() => {
     if (TARGET_USER_NAME) return TARGET_USER_NAME;
-    if (TARGET_USER_ID && (!me?.id || !sameId(TARGET_USER_ID, me.id))) return '';
+    if (TARGET_USER_ID && (!me?.id || !sameId(TARGET_USER_ID, me.id))) {
+      const stored = readStoredTrainee();
+      if (stored && sameId(stored.id, TARGET_USER_ID) && stored.name) {
+        return stored.name;
+      }
+      return '';
+    }
     return me?.name || 'Halle Angeles';
   });
   const [startDate, setStartDate] = useState(dayjs().format('YYYY-MM-DD'));
@@ -1106,6 +1113,9 @@ function App({ me, onSignOut }){
   const canEditSchedule = hasPerm('task.assign') && isPrivileged && !isTrainee;
   const canEditResponsible = hasPerm('task.update') && isPrivileged && !isTrainee;
   const canEditJournal = isTrainee || (isPrivileged && hasPerm('task.update'));
+  const hasAssignedPrograms = useMemo(() => userPrograms.length > 0, [userPrograms]);
+  const hasAssignedTasks = useMemo(() => weeks.some((week) => (week.tasks || []).length > 0), [weeks]);
+  const hideScheduleForPrivileged = isPrivileged && !hasAssignedPrograms && !hasAssignedTasks;
 
   useEffect(() => {
     if (typeof document === 'undefined') return undefined;
@@ -2832,6 +2842,11 @@ useEffect(() => {
       <button className="btn btn-ghost" title="Jump to today" onClick={()=> handleStartDateInput(dayjs().format('YYYY-MM-DD'))}>Today</button>
     </div>
   );
+  const emptyScheduleNotice = (
+    <div className="card p-6 text-center text-sm text-slate-500">
+      No assigned programs or orientation tasks yet. Assign a program to view the schedule.
+    </div>
+  );
 
   return (
     <div className="flex">
@@ -2875,7 +2890,11 @@ useEffect(() => {
         title={`${numWeeks}-Week Visual Calendar`}
         subtitle="Assign tasks by date; click Assign on a day."
       >
-        {calendarMode !== 'all' && programSummary && (
+        {hideScheduleForPrivileged ? (
+          emptyScheduleNotice
+        ) : (
+          <>
+            {calendarMode !== 'all' && programSummary && (
           <div className="mb-4">
             <ProgramOverviewCard programSummary={programSummary} />
           </div>
@@ -3092,15 +3111,20 @@ useEffect(() => {
             );
           })}
         </div>
-        {assignPicker && hasPerm('task.assign') && isPrivileged && !isTrainee && <AssignModal date={assignPicker.date} onClose={()=> setAssignPicker(null)} />}
-        {programModal.show && <ProgramModal program={programModal.program} onClose={()=> setProgramModal({show:false, program:null})} />}
+            {assignPicker && hasPerm('task.assign') && isPrivileged && !isTrainee && <AssignModal date={assignPicker.date} onClose={()=> setAssignPicker(null)} />}
+            {programModal.show && <ProgramModal program={programModal.program} onClose={()=> setProgramModal({show:false, program:null})} />}
+          </>
+        )}
       </Section>
       )}
 
       {/* Weeks & Tasks */}
       <Section title="Weeks & Tasks">
-        <div id="weeksTasks" data-weeks-root className="space-y-6">
-          {calendarMode === 'all' ? (
+        {hideScheduleForPrivileged ? (
+          emptyScheduleNotice
+        ) : (
+          <div id="weeksTasks" data-weeks-root className="space-y-6">
+            {calendarMode === 'all' ? (
             visibleProgramSet && visibleProgramSet.size === 0 ? (
               <div className="text-sm text-slate-500">
                 No programs selected. Use the filters above to choose which programs to display.
@@ -3389,7 +3413,8 @@ useEffect(() => {
               );
             })
           )}
-        </div>
+          </div>
+        )}
       </Section>
       {hasPerm('task.delete') && isPrivileged && !isTrainee && (
       <Section title="Deleted Tasks">


### PR DESCRIPTION
## Summary
- hide the calendar and weeks/task sections behind a privileged-only guard when no programs or orientation tasks exist
- show an inline empty state message that matches the current design when privileged users lack assignments
- add memoized helpers to detect assigned programs and tasks for the current view
- ensure the orientation view restores the selected trainee context when loading so privileged users only see the chosen user's calendar data

## Testing
- `npm test` *(fails: existing mismatch in __tests__/rbacRoutes.test.js expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68d405cfbba8832cb254336d3f251ca0