### PR TITLE
Clear privileged schedule when target lacks assignments

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -736,7 +736,8 @@ async function apiListUsers(){
 
 /* ---- Program & Template helpers ---- */
 async function apiListPrograms(){
-  const r = await fetch(`${API}/programs`, { credentials:'include' });
+  const url = withUser(`${API}/programs`);
+  const r = await fetch(url, { credentials:'include' });
   if(!r.ok) throw new Error('GET /programs failed');
   return r.json();
 }
@@ -944,7 +945,13 @@ function App({ me, onSignOut }){
   const [targetUserId, setTargetUserId] = useState(TARGET_USER_ID);
   const [targetUserName, setTargetUserName] = useState(() => {
     if (TARGET_USER_NAME) return TARGET_USER_NAME;
-    if (TARGET_USER_ID && (!me?.id || !sameId(TARGET_USER_ID, me.id))) return '';
+    if (TARGET_USER_ID && (!me?.id || !sameId(TARGET_USER_ID, me.id))) {
+      const stored = readStoredTrainee();
+      if (stored && sameId(stored.id, TARGET_USER_ID) && stored.name) {
+        return stored.name;
+      }
+      return '';
+    }
     return me?.name || 'Halle Angeles';
   });
   const [startDate, setStartDate] = useState(dayjs().format('YYYY-MM-DD'));
@@ -1106,6 +1113,9 @@ function App({ me, onSignOut }){
   const canEditSchedule = hasPerm('task.assign') && isPrivileged && !isTrainee;
   const canEditResponsible = hasPerm('task.update') && isPrivileged && !isTrainee;
   const canEditJournal = isTrainee || (isPrivileged && hasPerm('task.update'));
+  const hasAssignedPrograms = useMemo(() => userPrograms.length > 0, [userPrograms]);
+  const hasAssignedTasks = useMemo(() => weeks.some((week) => (week.tasks || []).length > 0), [weeks]);
+  const hideScheduleForPrivileged = isPrivileged && !hasAssignedPrograms && !hasAssignedTasks;
 
   useEffect(() => {
     if (typeof document === 'undefined') return undefined;
@@ -1540,51 +1550,72 @@ function App({ me, onSignOut }){
       }, []);
       if (signal?.aborted) return;
       setUserPrograms(mapped);
+      const viewingOtherUser = isPrivileged && me?.id && targetUserId && !sameId(targetUserId, me.id);
+      if (viewingOtherUser && programIds.length === 0) {
+        QS_PROGRAM_ID = null;
+        setActiveProgramId(null);
+        setCalendarMode('single');
+        setCalendarSelectValue('__current__');
+        setWeeks([]);
+        setDeletedTasks([]);
+        setNeedsInstantiate(false);
+        setAllCalendarEvents([]);
+        setAllCalendarPrograms([]);
+        calendarCacheRef.current.clear();
+        try {
+          localStorage.removeItem('anx_program_id');
+        } catch (err) {
+          // Ignore storage errors
+        }
+      }
     } catch (err) {
       if (signal?.aborted) return;
       console.error('Failed to load user programs', err);
       setUserPrograms([]);
     }
-  }, [targetUserId, hiddenProgramIds]);
+  }, [targetUserId, hiddenProgramIds, isPrivileged, me?.id]);
 
 
 /* Load tasks */
 useEffect(() => {
   async function load() {
     try {
-      // 1) Always ask the server first for the current user's preference
-      const prefs = await apiGetPrefs(); // NOTE: server /prefs returns current user's prefs by default
+      const viewingOtherUser = me?.id && targetUserId && !sameId(targetUserId, me.id);
+      const prefs = await apiGetPrefs(); // NOTE: server /prefs returns target-aware prefs by default
       let pid = prefs.program_id || null;
 
-      // 2) If the server has no preference yet, fall back to URL/localStorage
-      if (!pid) {
+      if (!pid && !viewingOtherUser) {
         pid = qs.get('program_id') || localStorage.getItem('anx_program_id') || null;
       }
 
       if (pid) {
-        // 3) Persist + tell server so future logins restore correctly
         QS_PROGRAM_ID = pid;
         setActiveProgramId(QS_PROGRAM_ID);
-        localStorage.setItem('anx_program_id', pid);
-        try { await apiPatchPrefs({ program_id: pid }); } catch (e) {}
-
-        // 4) Load tasks
+        setCalendarSelectValue(String(pid));
+        if (!viewingOtherUser) {
+          localStorage.setItem('anx_program_id', pid);
+          try { await apiPatchPrefs({ program_id: pid }); } catch (e) {}
+        }
         const count = await reloadTasks();
         setNeedsInstantiate(count === 0);
       } else {
-        // No program selected yet: clear UI
-        localStorage.removeItem('anx_program_id');
+        if (!viewingOtherUser) {
+          localStorage.removeItem('anx_program_id');
+        }
+        QS_PROGRAM_ID = null;
+        setActiveProgramId(null);
+        setCalendarMode('single');
+        setCalendarSelectValue('__current__');
         setWeeks([]);
         setDeletedTasks([]);
         setNeedsInstantiate(false);
-        setActiveProgramId(null);
       }
     } catch (err) {
       console.error('Failed to load tasks', err);
     }
   }
   load();
-}, []);
+}, [targetUserId, me?.id]);
 
   useEffect(() => {
     const signal = { aborted: false };
@@ -1955,6 +1986,7 @@ useEffect(() => {
 
   async function refreshPrograms(newId){
     try {
+      const viewingOtherUser = me?.id && targetUserId && !sameId(targetUserId, me.id);
       const previousProgramId = QS_PROGRAM_ID;
       const list = await apiListPrograms();
       if(newId !== undefined){
@@ -1965,9 +1997,12 @@ useEffect(() => {
       }
       const changedProgram = !sameId(previousProgramId, QS_PROGRAM_ID);
       if(QS_PROGRAM_ID){
-        localStorage.setItem('anx_program_id', QS_PROGRAM_ID);
         setActiveProgramId(QS_PROGRAM_ID);
-        try { await apiPatchPrefs({ program_id: QS_PROGRAM_ID }); } catch(e){}
+        setCalendarSelectValue(String(QS_PROGRAM_ID));
+        if (!viewingOtherUser) {
+          localStorage.setItem('anx_program_id', QS_PROGRAM_ID);
+          try { await apiPatchPrefs({ program_id: QS_PROGRAM_ID }); } catch(e){}
+        }
         if (changedProgram) {
           resetRangeOverrideForMode('single');
         }
@@ -1975,9 +2010,13 @@ useEffect(() => {
         if(!count){ setNeedsInstantiate(true); }
         else { setNeedsInstantiate(false); }
       } else {
-        localStorage.removeItem('anx_program_id');
+        if (!viewingOtherUser) {
+          localStorage.removeItem('anx_program_id');
+        }
         setWeeks([]); setDeletedTasks([]); setNeedsInstantiate(false);
         setActiveProgramId(null);
+        setCalendarMode('single');
+        setCalendarSelectValue('__current__');
         resetRangeOverrideForMode('single');
       }
       await updateUserPrograms(list);
@@ -2832,6 +2871,11 @@ useEffect(() => {
       <button className="btn btn-ghost" title="Jump to today" onClick={()=> handleStartDateInput(dayjs().format('YYYY-MM-DD'))}>Today</button>
     </div>
   );
+  const emptyScheduleNotice = (
+    <div className="card p-6 text-center text-sm text-slate-500">
+      No assigned programs or orientation tasks yet. Assign a program to view the schedule.
+    </div>
+  );
 
   return (
     <div className="flex">
@@ -2875,7 +2919,11 @@ useEffect(() => {
         title={`${numWeeks}-Week Visual Calendar`}
         subtitle="Assign tasks by date; click Assign on a day."
       >
-        {calendarMode !== 'all' && programSummary && (
+        {hideScheduleForPrivileged ? (
+          emptyScheduleNotice
+        ) : (
+          <>
+            {calendarMode !== 'all' && programSummary && (
           <div className="mb-4">
             <ProgramOverviewCard programSummary={programSummary} />
           </div>
@@ -3092,15 +3140,20 @@ useEffect(() => {
             );
           })}
         </div>
-        {assignPicker && hasPerm('task.assign') && isPrivileged && !isTrainee && <AssignModal date={assignPicker.date} onClose={()=> setAssignPicker(null)} />}
-        {programModal.show && <ProgramModal program={programModal.program} onClose={()=> setProgramModal({show:false, program:null})} />}
+            {assignPicker && hasPerm('task.assign') && isPrivileged && !isTrainee && <AssignModal date={assignPicker.date} onClose={()=> setAssignPicker(null)} />}
+            {programModal.show && <ProgramModal program={programModal.program} onClose={()=> setProgramModal({show:false, program:null})} />}
+          </>
+        )}
       </Section>
       )}
 
       {/* Weeks & Tasks */}
       <Section title="Weeks & Tasks">
-        <div id="weeksTasks" data-weeks-root className="space-y-6">
-          {calendarMode === 'all' ? (
+        {hideScheduleForPrivileged ? (
+          emptyScheduleNotice
+        ) : (
+          <div id="weeksTasks" data-weeks-root className="space-y-6">
+            {calendarMode === 'all' ? (
             visibleProgramSet && visibleProgramSet.size === 0 ? (
               <div className="text-sm text-slate-500">
                 No programs selected. Use the filters above to choose which programs to display.
@@ -3389,7 +3442,8 @@ useEffect(() => {
               );
             })
           )}
-        </div>
+          </div>
+        )}
       </Section>
       {hasPerm('task.delete') && isPrivileged && !isTrainee && (
       <Section title="Deleted Tasks">


### PR DESCRIPTION
## Summary
- clear the privileged calendar state when the selected trainee has no task assignments so stale schedules are hidden
- scope program preference persistence to the signed-in user while still loading target-specific selections for privileged viewers

## Testing
- `npm test` *(fails: existing mismatch in __tests__/rbacRoutes.test.js expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68d405cfbba8832cb254336d3f251ca0