### PR TITLE
Fetch all program templates across paginated API responses

### DIFF
--- a/public/admin/program-template-manager.html
+++ b/public/admin/program-template-manager.html
@@ -577,10 +577,10 @@
               <label class="flex items-center gap-2 font-semibold uppercase tracking-wide">
                 <span>Rows per page</span>
                 <select id="tmplPageSize" class="input w-24 text-sm font-medium normal-case">
-                  <option value="10" selected>10</option>
+                  <option value="10">10</option>
                   <option value="25">25</option>
                   <option value="50">50</option>
-                  <option value="all">All</option>
+                  <option value="all" selected>All</option>
                 </select>
               </label>
               <button id="tmplExportCsv" class="btn btn-outline text-sm">Export CSV</button>

--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -154,6 +154,100 @@ async function fetchProgramTemplates(params = {}) {
   return fetchJson(url);
 }
 
+function extractTemplatesFromResponse(payload) {
+  if (!payload || typeof payload !== 'object') {
+    return Array.isArray(payload) ? payload : [];
+  }
+  if (Array.isArray(payload.data)) return payload.data;
+  if (Array.isArray(payload.results)) return payload.results;
+  if (Array.isArray(payload.items)) return payload.items;
+  if (Array.isArray(payload.templates)) return payload.templates;
+  if (Array.isArray(payload.records)) return payload.records;
+  if (Array.isArray(payload.rows)) return payload.rows;
+  if (Array.isArray(payload.list)) return payload.list;
+  return [];
+}
+
+function parsePositiveInteger(value) {
+  if (value === Infinity) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return null;
+}
+
+async function fetchAllProgramTemplates(params = {}, options = {}) {
+  const baseParams = params && typeof params === 'object' ? { ...params } : {};
+  const { batchSize = 100, maxRequests = 20 } = options || {};
+  let offset = parsePositiveInteger(baseParams.offset);
+  if (!Number.isFinite(offset) || offset < 0) {
+    offset = 0;
+  }
+  delete baseParams.offset;
+  let limit = parsePositiveInteger(baseParams.limit);
+  if (!Number.isFinite(limit) || limit <= 0) {
+    const defaultBatch = parsePositiveInteger(batchSize);
+    limit = Number.isFinite(defaultBatch) && defaultBatch > 0 ? defaultBatch : 100;
+  }
+  delete baseParams.limit;
+
+  const aggregated = [];
+  let totalFromMeta = null;
+
+  for (let requestIndex = 0; requestIndex < maxRequests; requestIndex += 1) {
+    const requestParams = { ...baseParams };
+    if (Number.isFinite(limit) && limit > 0) {
+      requestParams.limit = limit;
+    }
+    if (offset) {
+      requestParams.offset = offset;
+    } else {
+      requestParams.offset = 0;
+    }
+
+    const response = await fetchProgramTemplates(requestParams);
+    const batch = extractTemplatesFromResponse(response);
+    if (batch.length) {
+      aggregated.push(...batch);
+    }
+
+    const meta = response && typeof response === 'object' ? response.meta : undefined;
+    const totalCandidate = meta?.total;
+    const parsedTotal = parsePositiveInteger(totalCandidate);
+    if (parsedTotal !== null) {
+      totalFromMeta = parsedTotal;
+    }
+
+    const limitCandidate = meta?.limit;
+    const parsedLimit = parsePositiveInteger(limitCandidate);
+    const effectiveLimit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : limit;
+    const offsetCandidate = Number.parseInt(meta?.offset, 10);
+
+    const reachedTotal = Number.isFinite(totalFromMeta) && aggregated.length >= totalFromMeta;
+    if (!batch.length || !Number.isFinite(effectiveLimit) || effectiveLimit <= 0) {
+      break;
+    }
+    if (batch.length < effectiveLimit) {
+      break;
+    }
+    if (reachedTotal) {
+      break;
+    }
+
+    if (Number.isFinite(offsetCandidate) && offsetCandidate >= 0) {
+      offset = offsetCandidate + effectiveLimit;
+    } else {
+      offset += effectiveLimit;
+    }
+  }
+
+  if (Number.isFinite(totalFromMeta) && aggregated.length >= totalFromMeta) {
+    return aggregated.slice(0, totalFromMeta);
+  }
+  return aggregated;
+}
+
 function createStatusBadge(status) {
   const normalized = (status || '').toLowerCase();
   const badgeClass = {
@@ -6556,19 +6650,7 @@ async function loadTemplates(options = {}) {
       params.status = status;
     }
     params.include_deleted = 'true';
-    const data = await fetchProgramTemplates(params);
-    let fetched = [];
-    if (Array.isArray(data?.data)) {
-      fetched = data.data;
-    } else if (Array.isArray(data?.results)) {
-      fetched = data.results;
-    } else if (Array.isArray(data?.items)) {
-      fetched = data.items;
-    } else if (Array.isArray(data)) {
-      fetched = data;
-    } else if (Array.isArray(data?.templates)) {
-      fetched = data.templates;
-    }
+    const fetched = await fetchAllProgramTemplates(params);
     globalTemplates = Array.isArray(fetched) ? fetched : [];
     if (typeof hydrateTemplatesWithAudit === 'function') {
       hydrateTemplatesWithAudit(globalTemplates);


### PR DESCRIPTION
## Summary
- add helpers to gather templates from paginated API responses until all records are collected
- update the template loader to use the paginated fetcher so the table can render every template when no filters are applied

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d43a24eaa4832cbbc64ce3b2ba5726