### PR TITLE
Handle missing template audit endpoint

### DIFF
--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -2987,7 +2987,16 @@ async function fetchTemplateAuditRecords(templateId) {
   params.set('action', 'INSERT');
   params.set('operation', 'INSERT');
   const url = `${API}/api/audit?${params.toString()}`;
-  const payload = await fetchJson(url);
+  let payload = null;
+  try {
+    payload = await fetchJson(url);
+  } catch (error) {
+    if (error && error.status === 404) {
+      console.info('Template audit endpoint unavailable, continuing without audit records.');
+      return { records: [], info: null };
+    }
+    throw error;
+  }
   const records = extractAuditEntriesFromPayload(payload, templateId);
   const candidate = findInsertAuditCandidate(records);
   const info = candidate


### PR DESCRIPTION
## Summary
- prevent fetchTemplateAuditRecords from throwing when the audit endpoint returns 404
- return empty audit data and log an informational message when audit records are unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d446aa8258832c862cbb7c11a82ab4