### PR TITLE
Handle missing audit endpoint without errors

### DIFF
--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -2969,8 +2969,13 @@ function hydrateTemplateLibraryIndex() {
   });
 }
 
+let templateAuditApiAvailable = true;
+
 async function fetchTemplateAuditRecords(templateId) {
   if (!templateId) {
+    return { records: [], info: null };
+  }
+  if (!templateAuditApiAvailable) {
     return { records: [], info: null };
   }
   const params = new URLSearchParams();
@@ -2987,7 +2992,17 @@ async function fetchTemplateAuditRecords(templateId) {
   params.set('action', 'INSERT');
   params.set('operation', 'INSERT');
   const url = `${API}/api/audit?${params.toString()}`;
-  const payload = await fetchJson(url);
+  let payload = null;
+  try {
+    payload = await fetchJson(url);
+  } catch (error) {
+    if (error && error.status === 404) {
+      console.info('Template audit endpoint unavailable, continuing without audit records.');
+      templateAuditApiAvailable = false;
+      return { records: [], info: null };
+    }
+    throw error;
+  }
   const records = extractAuditEntriesFromPayload(payload, templateId);
   const candidate = findInsertAuditCandidate(records);
   const info = candidate
@@ -3129,6 +3144,13 @@ function ensureTemplateAudit(template) {
       templateAuditState.set(templateId, readyState);
       applyTemplateAuditData(templateId, readyState.info, readyState.records);
     } catch (error) {
+      if (error && error.status === 404) {
+        const readyState = { status: 'ready', info: null, records: null };
+        templateAuditState.set(templateId, readyState);
+        applyTemplateAuditData(templateId, null, null);
+        templateAuditApiAvailable = false;
+        return;
+      }
       console.error('Failed to load template audit', error);
       templateAuditState.set(templateId, { status: 'error', info: null, records: null, error });
     } finally {


### PR DESCRIPTION
## Summary
- stop requesting template audit data once the audit endpoint responds with 404
- treat missing audit support as a successful load so the UI renders without console errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d446aa8258832c862cbb7c11a82ab4