### PR TITLE
Short-circuit template audit fetches when disabled

### DIFF
--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -2969,9 +2969,237 @@ function hydrateTemplateLibraryIndex() {
   });
 }
 
+let templateAuditApiAvailable = true;
+let templateAuditApiAvailabilityState = 'unknown';
+let templateAuditApiAvailabilityPromise = null;
+let templateAuditUnavailableLogged = false;
+
+const TEMPLATE_AUDIT_AVAILABILITY_STORAGE_KEY = 'anx:template-audit:availability';
+let templateAuditFeatureEnabledPreference = null;
+
+const truthyFeatureValues = new Set(['1', 'true', 't', 'y', 'yes', 'enabled', 'on', 'available']);
+const falsyFeatureValues = new Set(['0', 'false', 'f', 'n', 'no', 'disabled', 'off', 'unavailable']);
+
+function normalizeBooleanInput(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) return null;
+    if (value === 0) return false;
+    return value !== 0;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return null;
+  if (truthyFeatureValues.has(normalized)) return true;
+  if (falsyFeatureValues.has(normalized)) return false;
+  return null;
+}
+
+function safeGetStorageItem(storage, key) {
+  if (!storage || typeof storage.getItem !== 'function') return null;
+  try {
+    return storage.getItem(key);
+  } catch (_err) {
+    return null;
+  }
+}
+
+function safeSetStorageItem(storage, key, value) {
+  if (!storage || typeof storage.setItem !== 'function') return false;
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
+
+function readStoredTemplateAuditPreference() {
+  const raw = safeGetStorageItem(window?.sessionStorage, TEMPLATE_AUDIT_AVAILABILITY_STORAGE_KEY)
+    ?? safeGetStorageItem(window?.localStorage, TEMPLATE_AUDIT_AVAILABILITY_STORAGE_KEY);
+  const coerced = normalizeBooleanInput(raw);
+  return coerced;
+}
+
+function persistTemplateAuditPreference(enabled) {
+  const value = enabled ? 'enabled' : 'disabled';
+  const wroteSession = safeSetStorageItem(window?.sessionStorage, TEMPLATE_AUDIT_AVAILABILITY_STORAGE_KEY, value);
+  if (!wroteSession) {
+    safeSetStorageItem(window?.localStorage, TEMPLATE_AUDIT_AVAILABILITY_STORAGE_KEY, value);
+  }
+}
+
+function readBooleanMetaFlag(names = []) {
+  if (typeof document === 'undefined') return null;
+  for (const name of names) {
+    if (!name) continue;
+    const meta = document.querySelector(`meta[name="${name}"]`);
+    if (!meta) continue;
+    const content = meta.getAttribute('content');
+    const coerced = normalizeBooleanInput(content);
+    if (coerced !== null) return coerced;
+  }
+  return null;
+}
+
+function readBooleanDatasetFlag(keys = []) {
+  if (typeof document === 'undefined') return null;
+  const dataset = document.body?.dataset;
+  if (!dataset) return null;
+  for (const key of keys) {
+    if (!key) continue;
+    const value = dataset[key] ?? dataset[key.replace(/-([a-z])/g, (_, ch) => ch.toUpperCase())];
+    const coerced = normalizeBooleanInput(value);
+    if (coerced !== null) return coerced;
+  }
+  return null;
+}
+
+function readBooleanWindowFlag(paths = []) {
+  if (typeof window === 'undefined') return null;
+  for (const path of paths) {
+    if (!Array.isArray(path) || !path.length) continue;
+    let node = window;
+    let valid = true;
+    for (const segment of path) {
+      if (node && typeof node === 'object' && segment in node) {
+        node = node[segment];
+      } else {
+        valid = false;
+        break;
+      }
+    }
+    if (!valid) continue;
+    const coerced = normalizeBooleanInput(node);
+    if (coerced !== null) return coerced;
+  }
+  return null;
+}
+
+function getUserPermissions(user = getEffectiveCurrentUser()) {
+  if (!user || typeof user !== 'object') return [];
+  const collection = [];
+  const addCandidate = (value) => {
+    if (value === null || value === undefined) return;
+    if (Array.isArray(value)) {
+      value.forEach(addCandidate);
+      return;
+    }
+    const normalized = String(value).trim();
+    if (!normalized) return;
+    collection.push(normalized);
+  };
+  addCandidate(user.permissions);
+  addCandidate(user.permission);
+  addCandidate(user.perms);
+  addCandidate(user.perm);
+  addCandidate(user.permissions_list);
+  addCandidate(user.permission_list);
+  addCandidate(user.permissionKeys);
+  addCandidate(user.permission_keys);
+  return collection
+    .map(value => value.toLowerCase())
+    .filter(Boolean);
+}
+
+function detectAuditPermissionSignal() {
+  const perms = getUserPermissions();
+  if (!perms.length) return null;
+  if (perms.some(permission => permission.includes('audit'))) {
+    return true;
+  }
+  return null;
+}
+
+function evaluateTemplateAuditFeaturePreference() {
+  if (templateAuditFeatureEnabledPreference !== null) {
+    return templateAuditFeatureEnabledPreference;
+  }
+  const stored = readStoredTemplateAuditPreference();
+  if (stored !== null) {
+    templateAuditFeatureEnabledPreference = stored;
+    return templateAuditFeatureEnabledPreference;
+  }
+  const explicitMeta = readBooleanMetaFlag([
+    'template-audit-enabled',
+    'templateAuditEnabled',
+    'anx:template-audit-enabled',
+    'anx:template-audit',
+  ]);
+  if (explicitMeta !== null) {
+    templateAuditFeatureEnabledPreference = explicitMeta;
+    return templateAuditFeatureEnabledPreference;
+  }
+  const bodyDataset = readBooleanDatasetFlag([
+    'templateAudit',
+    'templateAuditEnabled',
+    'template-audit',
+    'template-audit-enabled',
+  ]);
+  if (bodyDataset !== null) {
+    templateAuditFeatureEnabledPreference = bodyDataset;
+    return templateAuditFeatureEnabledPreference;
+  }
+  const windowFlag = readBooleanWindowFlag([
+    ['ANX', 'features', 'templateAudit'],
+    ['ANX', 'features', 'template_audit'],
+    ['ANX', 'featureFlags', 'templateAudit'],
+    ['ANX', 'featureFlags', 'template_audit'],
+    ['APP_CONFIG', 'templateAuditEnabled'],
+    ['APP', 'config', 'templateAuditEnabled'],
+    ['CONFIG', 'features', 'templateAudit'],
+    ['CONFIG', 'features', 'template_audit'],
+    ['RBAC', 'featureFlags', 'templateAudit'],
+    ['RBAC', 'featureFlags', 'template_audit'],
+    ['AUTH', 'features', 'templateAudit'],
+    ['AUTH', 'features', 'template_audit'],
+  ]);
+  if (windowFlag !== null) {
+    templateAuditFeatureEnabledPreference = windowFlag;
+    return templateAuditFeatureEnabledPreference;
+  }
+  const permissionSignal = detectAuditPermissionSignal();
+  if (permissionSignal !== null) {
+    templateAuditFeatureEnabledPreference = permissionSignal;
+    return templateAuditFeatureEnabledPreference;
+  }
+  templateAuditFeatureEnabledPreference = false;
+  return templateAuditFeatureEnabledPreference;
+}
+
+function setTemplateAuditFeaturePreference(enabled, { persist = false } = {}) {
+  if (enabled === null || enabled === undefined) return;
+  templateAuditFeatureEnabledPreference = Boolean(enabled);
+  if (persist) {
+    persistTemplateAuditPreference(templateAuditFeatureEnabledPreference);
+  }
+}
+
+function shouldAttemptTemplateAuditFetch() {
+  return evaluateTemplateAuditFeaturePreference();
+}
+
 async function fetchTemplateAuditRecords(templateId) {
   if (!templateId) {
     return { records: [], info: null };
+  }
+  if (!shouldAttemptTemplateAuditFetch()) {
+    templateAuditApiAvailable = false;
+    templateAuditApiAvailabilityState = 'unavailable';
+    return { records: [], info: null };
+  }
+  if (!templateAuditApiAvailable || templateAuditApiAvailabilityState === 'unavailable') {
+    return { records: [], info: null };
+  }
+  if (templateAuditApiAvailabilityState === 'checking' && templateAuditApiAvailabilityPromise) {
+    try {
+      await templateAuditApiAvailabilityPromise;
+    } catch (error) {
+      // the awaited promise already handled setting state and logging
+    }
+    if (!templateAuditApiAvailable || templateAuditApiAvailabilityState === 'unavailable') {
+      return { records: [], info: null };
+    }
   }
   const params = new URLSearchParams();
   params.set('table', TEMPLATE_AUDIT_TABLE_NAME);
@@ -2987,7 +3215,50 @@ async function fetchTemplateAuditRecords(templateId) {
   params.set('action', 'INSERT');
   params.set('operation', 'INSERT');
   const url = `${API}/api/audit?${params.toString()}`;
-  const payload = await fetchJson(url);
+  let payload = null;
+  const performFetch = async () => {
+    try {
+      const responsePayload = await fetchJson(url);
+      templateAuditApiAvailable = true;
+      templateAuditApiAvailabilityState = 'available';
+      setTemplateAuditFeaturePreference(true, { persist: true });
+      return responsePayload;
+    } catch (error) {
+      if (error && error.status === 404) {
+        templateAuditApiAvailable = false;
+        templateAuditApiAvailabilityState = 'unavailable';
+        if (!templateAuditUnavailableLogged) {
+          console.info('Template audit endpoint unavailable, continuing without audit records.');
+          templateAuditUnavailableLogged = true;
+        }
+        setTemplateAuditFeaturePreference(false, { persist: true });
+        return null;
+      }
+      templateAuditApiAvailabilityState = 'unknown';
+      throw error;
+    }
+  };
+
+  if (templateAuditApiAvailabilityState !== 'available') {
+    templateAuditApiAvailabilityState = 'checking';
+    const availabilityPromise = performFetch();
+    templateAuditApiAvailabilityPromise = availabilityPromise;
+    try {
+      payload = await availabilityPromise;
+    } finally {
+      if (templateAuditApiAvailabilityPromise === availabilityPromise) {
+        templateAuditApiAvailabilityPromise = null;
+        if (templateAuditApiAvailabilityState === 'checking') {
+          templateAuditApiAvailabilityState = templateAuditApiAvailable ? 'available' : 'unavailable';
+        }
+      }
+    }
+  } else {
+    payload = await performFetch();
+  }
+  if (payload === null) {
+    return { records: [], info: null };
+  }
   const records = extractAuditEntriesFromPayload(payload, templateId);
   const candidate = findInsertAuditCandidate(records);
   const info = candidate
@@ -3107,6 +3378,7 @@ function ensureTemplateAudit(template) {
 
   const inline = extractTemplateAuditFromTemplate(template);
   if (inline && inline.info) {
+    setTemplateAuditFeaturePreference(true);
     const readyState = {
       status: 'ready',
       info: inline.info,
@@ -3129,6 +3401,14 @@ function ensureTemplateAudit(template) {
       templateAuditState.set(templateId, readyState);
       applyTemplateAuditData(templateId, readyState.info, readyState.records);
     } catch (error) {
+      if (error && error.status === 404) {
+        const readyState = { status: 'ready', info: null, records: null };
+        templateAuditState.set(templateId, readyState);
+        applyTemplateAuditData(templateId, null, null);
+        templateAuditApiAvailable = false;
+        setTemplateAuditFeaturePreference(false, { persist: true });
+        return;
+      }
       console.error('Failed to load template audit', error);
       templateAuditState.set(templateId, { status: 'error', info: null, records: null, error });
     } finally {


### PR DESCRIPTION
## Summary
- add client-side feature flag detection and persistence for the template audit endpoint
- avoid issuing audit fetches when the feature is disabled and persist 404 detections
- sync inline audit hydration with the availability tracker for consistent behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d446aa8258832c862cbb7c11a82ab4