### PR TITLE
Ensure All Programs view fetches loaded user tasks

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -267,12 +267,23 @@ const normalizeWeekNumber = (value) => {
   return Number.isNaN(parsed) ? null : parsed;
 };
 const uid = () => Math.random().toString(36).slice(2);
-const withUser = (url) => {
-  if (TARGET_USER_ID && CURRENT_USER_ID && TARGET_USER_ID !== CURRENT_USER_ID) {
-    const sep = url.includes('?') ? '&' : '?';
-    return `${url}${sep}user_id=${encodeURIComponent(TARGET_USER_ID)}`;
+const withUser = (url, options = {}) => {
+  const { force = false } = options || {};
+  if (!url) return url;
+  const normalizedTarget = TARGET_USER_ID ? String(TARGET_USER_ID) : null;
+  const normalizedCurrent = CURRENT_USER_ID ? String(CURRENT_USER_ID) : null;
+  if (!normalizedTarget) return url;
+  if (!force && normalizedCurrent && normalizedTarget === normalizedCurrent) {
+    return url;
   }
-  return url;
+  if (url.includes('user_id=')) {
+    return url;
+  }
+  const hasQuery = url.includes('?');
+  const needsAmpersand = hasQuery && !/[?&]$/.test(url);
+  const base = hasQuery ? url : `${url}?`;
+  const connector = needsAmpersand ? '&' : '';
+  return `${base}${connector}user_id=${encodeURIComponent(normalizedTarget)}`;
 };
 const withUserBody = (data = {}) => (
   (TARGET_USER_ID && CURRENT_USER_ID && TARGET_USER_ID !== CURRENT_USER_ID)
@@ -1907,7 +1918,12 @@ useEffect(() => {
     }
     (async () => {
       try {
-        const rows = await apiGetTasks({ include_deleted: false });
+        const requestedUserId = targetUserId ? String(targetUserId) : null;
+        const taskParams = { include_deleted: false };
+        if (requestedUserId) {
+          taskParams.user_id = requestedUserId;
+        }
+        const rows = await apiGetTasks(taskParams);
         if (cancelled) return;
         const dedupe = new Map();
         (Array.isArray(rows) ? rows : []).forEach((row) => {


### PR DESCRIPTION
## Summary
- extend the `withUser` helper to handle optional forcing and avoid duplicating user_id query parameters
- ensure the All Programs calendar fetch includes the loaded user's identifier when retrieving tasks

## Testing
- npm test -- --runInBand *(fails: existing expectation mismatch in user update test)*

------
https://chatgpt.com/codex/tasks/task_e_68d49d8f3ef8832c8acc863efadd56ce