### PR TITLE
Add sign-in header and standalone sign-in page

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -3710,6 +3710,21 @@ useEffect(() => {
   );
 }
 
+function LandingNav(){
+  return (
+    <header className="bg-slate-50/90 border-b border-slate-200/60 backdrop-blur">
+      <nav
+        className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-start lg:justify-end"
+        aria-label="Primary"
+      >
+        <a href="/signin.html" className="btn btn-primary">
+          Sign In
+        </a>
+      </nav>
+    </header>
+  );
+}
+
 function LandingHero(){
   const handleGetStarted = useCallback(() => {
     const el = document.getElementById('auth-start');
@@ -3861,6 +3876,7 @@ function Root(){
   if (!me){
     return (
       <div className="min-h-screen bg-slate-50">
+        <LandingNav />
         <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-16 space-y-16">
           <LandingHero />
           <EnterpriseFeatures />

--- a/public/signin.html
+++ b/public/signin.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANX • Sign In</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { theme: { extend: { colors: { anx: { sky: '#0ea5e9', mint:'#10b981', slate:'#1f2937' }}}}};
+  </script>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="min-h-screen bg-slate-50 text-slate-900">
+  <div id="root" class="min-h-screen"></div>
+
+  <script type="text/babel" data-presets="env,react">
+    const { useState } = React;
+    const API = window.location.origin;
+
+    function LandingNav(){
+      return (
+        <header className="bg-slate-50/90 border-b border-slate-200/60 backdrop-blur">
+          <nav
+            className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex justify-start lg:justify-end"
+            aria-label="Primary"
+          >
+            <a href="/orientation_index.html" className="btn btn-ghost">
+              Back to Orientation
+            </a>
+          </nav>
+        </header>
+      );
+    }
+
+    function AuthPanel({ onAuthed }){
+      const [mode, setMode] = useState('login');
+      const [u, setU] = useState('');
+      const [p, setP] = useState('');
+      const [confirmPassword, setConfirmPassword] = useState('');
+      const [name, setName] = useState('');
+      const [email, setEmail] = useState('');
+      const [err, setErr] = useState('');
+      const [showPassword, setShowPassword] = useState(false);
+
+      async function doLogin(e){
+        e.preventDefault(); setErr('');
+        const r = await fetch(`${API}/auth/local/login`, {
+          method:'POST', headers:{'Content-Type':'application/json'}, credentials:'include',
+          body: JSON.stringify({ username: u.trim(), password: p })
+        });
+        if(!r.ok){ setErr('Login failed.'); return; }
+        onAuthed();
+      }
+      async function doRegister(e){
+        e.preventDefault();
+        if (p !== confirmPassword) {
+          setErr('Passwords do not match.');
+          return;
+        }
+        setErr('');
+        const r = await fetch(`${API}/auth/local/register`, {
+          method:'POST', headers:{'Content-Type':'application/json'}, credentials:'include',
+          body: JSON.stringify({ username: u.trim(), password: p, full_name: name.trim(), email: email.trim() })
+        });
+        if(!r.ok){ setErr('Registration failed (username taken?).'); return; }
+        onAuthed();
+      }
+      function doGoogle(){
+        window.location.href = `${API}/auth/google`;
+      }
+
+      return (
+        <div className="max-w-4xl mx-auto grid md:grid-cols-2 gap-8">
+          <div className="card p-6">
+            <h2 className="text-xl font-semibold mb-4">{mode === 'login' ? 'Sign in' : 'Create an account'}</h2>
+            <p className="text-sm text-slate-500 mb-4">Use a local account as an alternate to Google SSO.</p>
+            {mode === 'register' && (
+              <>
+                <div className="mb-4">
+                  <label htmlFor="fullName" className="text-sm block mb-1">Full name</label>
+                  <input id="fullName" className="input" value={name} onChange={e=>setName(e.target.value)} placeholder="Your name" />
+                </div>
+                <div className="mb-4">
+                  <label htmlFor="email" className="text-sm block mb-1">Email</label>
+                  <input id="email" className="input" value={email} onChange={e=>setEmail(e.target.value)} placeholder="you@anx.com" />
+                </div>
+              </>
+            )}
+            <div className="mb-4">
+              <label htmlFor="username" className="text-sm block mb-1">Username</label>
+              <input id="username" className="input" value={u} onChange={e=>setU(e.target.value)} placeholder="e.g., halle" />
+            </div>
+            <div className="mb-4">
+              <label htmlFor="password" className="text-sm block mb-1">Password</label>
+              <div className="relative">
+                <input
+                  id="password"
+                  className="input pr-10"
+                  type={showPassword ? 'text' : 'password'}
+                  value={p}
+                  onChange={e=>setP(e.target.value)}
+                  placeholder="••••••••"
+                />
+                <button
+                  type="button"
+                  className="absolute inset-y-0 right-3 flex items-center text-slate-500 hover:text-slate-700"
+                  onClick={()=>setShowPassword(v=>!v)}
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                >
+                  <span aria-hidden="true">{showPassword ? '🙈' : '👁️'}</span>
+                </button>
+              </div>
+            </div>
+            {mode === 'register' && (
+              <div className="mb-4">
+                <label htmlFor="confirmPassword" className="text-sm block mb-1">Confirm password</label>
+                <input
+                  id="confirmPassword"
+                  className="input"
+                  type={showPassword ? 'text' : 'password'}
+                  value={confirmPassword}
+                  onChange={e=>setConfirmPassword(e.target.value)}
+                  placeholder="••••••••"
+                />
+              </div>
+            )}
+            {err && (
+              <p className="text-sm text-red-600 mb-4" role="alert">{err}</p>
+            )}
+            <div className="flex flex-col items-center space-y-2 mt-2">
+              {mode === 'login' ? (
+                <button className="btn btn-primary w-full" onClick={doLogin}>Sign in</button>
+              ) : (
+                <button className="btn btn-primary w-full" onClick={doRegister}>Create account</button>
+              )}
+
+              <div className="flex justify-between w-full text-sm text-center">
+                <button
+                  className="btn btn-ghost flex-1"
+                  onClick={() => setMode(mode === 'login' ? 'register' : 'login')}
+                >
+                  {mode === 'login'
+                    ? 'Need an account? Register'
+                    : 'Already have an account? Sign in'}
+                </button>
+
+                <a href="/reset.html" className="btn btn-ghost flex-1">
+                  Reset Password
+                </a>
+              </div>
+            </div>
+            <div className="h-px bg-slate-200 my-4"></div>
+            <button className="btn btn-outline w-full" onClick={doGoogle}>Continue with Google</button>
+          </div>
+          <div className="card p-6">
+            <h3 className="text-lg font-semibold mb-4">Welcome to ANX Orientation</h3>
+            <p className="text-sm text-slate-600 mb-4">
+              Sign in to load your calendar, tasks, and preferences. Your session is stored securely and restores your last view.
+            </p>
+            <ul className="list-disc pl-5 text-sm text-slate-600 space-y-1">
+              <li>Use <strong>local username/password</strong> or <strong>Google SSO</strong>.</li>
+              <li>Your tasks are tied to your account and won’t mix with others.</li>
+              <li>Safe for FileMaker Web Viewer (cookies: SameSite=Lax).</li>
+            </ul>
+          </div>
+        </div>
+      );
+    }
+
+    function SignInPage(){
+      return (
+        <div className="min-h-screen bg-slate-50">
+          <LandingNav />
+          <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-16">
+            <section className="card p-6 sm:p-10">
+              <AuthPanel onAuthed={() => { window.location.href = '/orientation_index.html'; }} />
+            </section>
+          </main>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<SignInPage />);
+  </script>
+
+  <style>
+    .card{ @apply bg-white rounded-2xl shadow-sm border border-slate-100; }
+    .btn{ @apply inline-flex items-center gap-2 px-3 py-2 rounded-xl border text-sm; }
+    .btn-ghost{ @apply border-transparent hover:bg-slate-50; }
+    .btn-outline{ @apply border-slate-300 hover:bg-slate-50; }
+    .btn-primary{ @apply bg-anx-sky text-white border-anx-sky hover:brightness-95; }
+    .input{ @apply w-full border rounded-xl px-3 py-2 text-sm; }
+
+    button:focus,
+    [tabindex]:focus,
+    input:focus,
+    textarea:focus,
+    select:focus{
+      @apply outline-none ring-2 ring-anx-sky;
+    }
+  </style>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a landing header with a primary sign-in button on the orientation page
- provide a standalone sign-in page that reuses the existing AuthPanel component and styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d87c899f34832cb8c05c2a29686247