### PR TITLE
Add themed gradients for orientation auth screen

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -28,6 +28,26 @@
     .textarea{ @apply w-full border rounded-xl px-3 py-2 text-sm; }
     .outline-dashed{ outline-style: dashed; }
 
+    :root {
+      --auth-gradient-start: #f8fafc;
+      --auth-gradient-end: #e2e8f0;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --auth-gradient-start: #0f172a;
+        --auth-gradient-end: #1e293b;
+      }
+      body {
+        color: #e2e8f0;
+      }
+    }
+
+    .auth-screen {
+      background-image: linear-gradient(160deg, var(--auth-gradient-start), var(--auth-gradient-end));
+      background-color: var(--auth-gradient-end);
+    }
+
     .orientation-calendar__tooltip {
       position: absolute;
       top: 0;
@@ -99,8 +119,10 @@
     html, body { height: 100%; }
   </style>
 </head>
-<body class="min-h-screen bg-slate-50 text-slate-900">
-<div id="root" class="max-w-7xl mx-auto px-4"></div>
+<body class="text-slate-900">
+<div class="min-h-screen auth-screen">
+  <div id="root" class="max-w-7xl mx-auto px-4"></div>
+</div>
 
 <script type="text/babel" data-presets="env,react">
 const { useEffect, useMemo, useState, useRef, useCallback } = React;


### PR DESCRIPTION
## Summary
- add CSS variables that expose light and dark gradients for the orientation auth screen
- wrap the orientation root container with a gradient host so the theme fills the viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d962736dbc832cb334f71e3c383618