### PR TITLE
Reset range overrides when opening All Programs view

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -1218,6 +1218,7 @@ function App({ me, onSignOut }){
   useEffect(() => {
     rangeOverrideRef.current = rangeOverride;
   }, [rangeOverride]);
+
   const markRangeOverrideForCurrentMode = useCallback(() => {
     const key = calendarMode === 'all' ? 'all' : 'single';
     setRangeOverride((prev) => {
@@ -1240,6 +1241,11 @@ function App({ me, onSignOut }){
       return { single: false, all: false };
     });
   }, []);
+
+  useEffect(() => {
+    if (calendarMode !== 'all') return;
+    resetRangeOverrideForMode('all');
+  }, [calendarMode, resetRangeOverrideForMode]);
   const getProgramPalette = useCallback((programId, colorInput) => {
     const key = `${String(programId || '')}::${String(colorInput || '')}`;
     if (programColorCache.current.has(key)) {
@@ -2638,6 +2644,7 @@ useEffect(() => {
   const handleProgramSelectChange = (event) => {
     const value = event.target.value;
     if (value === '__all__') {
+      resetRangeOverrideForMode('all');
       setCalendarMode('all');
       setCalendarSelectValue('__all__');
       return;


### PR DESCRIPTION
## Summary
- clear the range override flag when switching to the All Programs calendar option so the auto-derived window is applied
- ensure programmatic transitions into All Programs mode also reset the override for aggregated range calculations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d978f0c098832caf83d979b92b0efd