### PR TITLE
Trust proxy headers for Google OAuth

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -207,7 +207,8 @@ passport.deserializeUser(async (id, done) => {
 passport.use(new GoogleStrategy({
   clientID:     process.env.GOOGLE_CLIENT_ID || '80329949703-haj7aludbp14ma3fbg4h97rna0ngbn28.apps.googleusercontent.com',
   clientSecret: process.env.GOOGLE_CLIENT_SECRET || 'ZHhm_oFXdv7C9FELx-bSdsmt',
-  callbackURL:  process.env.GOOGLE_CALLBACK_URL || '/auth/google/callback'
+  callbackURL:  process.env.GOOGLE_CALLBACK_URL || '/auth/google/callback',
+  proxy: true
 }, async (_at, _rt, profile, done) => {
   try {
     const email   = profile.emails?.[0]?.value || null;


### PR DESCRIPTION
## Summary
- enable Passport's GoogleStrategy to honor proxy headers when determining callback URLs
- keep the existing callbackURL override behavior intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d98f58c61c832c89a079c9f7fc8bf1