### PR TITLE
Remove dark mode overrides from orientation auth screen

### DIFF
--- a/public/orientation_index.html
+++ b/public/orientation_index.html
@@ -38,19 +38,6 @@
       --auth-input-error-text: #b91c1c;
     }
 
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --auth-gradient-start: #0f172a;
-        --auth-gradient-end: #1e293b;
-        --auth-input-error-border: #fca5a5;
-        --auth-input-error-bg: rgba(248, 113, 113, 0.16);
-        --auth-input-error-text: #fecaca;
-      }
-      body {
-        color: #e2e8f0;
-      }
-    }
-
     .auth-error-alert{
       display: flex;
       align-items: flex-start;


### PR DESCRIPTION
## Summary
- remove the dark mode-specific gradient overrides from the orientation auth page so it uses the default theme variables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da116df8b0832c81bcaa8f28998e48