### PR TITLE
Add support for program department and discipline metadata

### DIFF
--- a/__tests__/programApiMetadata.test.ts
+++ b/__tests__/programApiMetadata.test.ts
@@ -1,0 +1,37 @@
+import { createProgram, getPrograms, patchProgram, Program } from '../src/api';
+
+describe('program metadata normalization and payloads', () => {
+  test('getPrograms exposes department and discipline metadata from mock seed', async () => {
+    const response = await getPrograms();
+    expect(response.data.length).toBeGreaterThan(0);
+    const sample = response.data[0] as Program;
+    expect(sample.disciplineType).toBe('Technical');
+    expect(sample.department).toBe('Engineering');
+  });
+
+  test('createProgram trims metadata fields before returning', async () => {
+    const created = await createProgram({
+      name: 'Metadata Program',
+      department: '  Research  ',
+      disciplineType: '  STEM  ',
+    });
+    expect(created.department).toBe('Research');
+    expect(created.disciplineType).toBe('STEM');
+  });
+
+  test('patchProgram accepts aliases and clears empty metadata', async () => {
+    const updated = await patchProgram('p1', {
+      dept: '  Support  ',
+      discipline: '  Customer Success  ',
+    } as unknown as Partial<Program>);
+    expect(updated.department).toBe('Support');
+    expect(updated.disciplineType).toBe('Customer Success');
+
+    const cleared = await patchProgram('p1', {
+      department: '   ',
+      disciplineType: '   ',
+    });
+    expect(cleared.department).toBeNull();
+    expect(cleared.disciplineType).toBeNull();
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -14,6 +14,8 @@ export interface Program {
   assignedCount: number;
   organization: string | null;
   subUnit: string | null;
+  disciplineType?: string | null;
+  department?: string | null;
 }
 
 export interface Template {
@@ -278,6 +280,8 @@ const normalizeProgram = (raw: any): Program => {
       assignedCount: 0,
       organization: null,
       subUnit: null,
+      disciplineType: null,
+      department: null,
     };
   }
 
@@ -342,6 +346,29 @@ const normalizeProgram = (raw: any): Program => {
     subUnit = null;
   }
 
+  const disciplineSource =
+    raw.disciplineType ??
+    raw.discipline_type ??
+    raw.discipline ??
+    raw.programDiscipline ??
+    null;
+  let disciplineType: string | null = null;
+  if (typeof disciplineSource === 'string') {
+    const trimmed = disciplineSource.trim();
+    disciplineType = trimmed ? trimmed : null;
+  } else if (disciplineSource === null) {
+    disciplineType = null;
+  }
+
+  const departmentSource = raw.department ?? raw.dept ?? raw.departmentName ?? raw.department_name ?? null;
+  let department: string | null = null;
+  if (typeof departmentSource === 'string') {
+    const trimmed = departmentSource.trim();
+    department = trimmed ? trimmed : null;
+  } else if (departmentSource === null) {
+    department = null;
+  }
+
   return {
     id: String(idCandidate ?? ''),
     name:
@@ -358,6 +385,8 @@ const normalizeProgram = (raw: any): Program => {
     assignedCount,
     organization,
     subUnit,
+    disciplineType,
+    department,
   };
 };
 
@@ -532,8 +561,14 @@ const buildProgramWritePayload = (payload: Partial<Program>): Record<string, unk
     assignedCount: _assignedCount,
     organization,
     subUnit,
-    ...rest
-  } = payload;
+    disciplineType,
+    department,
+    ...restWithExtras
+  } = payload as Partial<Program> & { dept?: string | null; discipline?: string | null };
+  const { dept: _dept, discipline: _discipline, ...rest } = restWithExtras as typeof restWithExtras & {
+    dept?: unknown;
+    discipline?: unknown;
+  };
   const body: Record<string, unknown> = { ...rest };
   if (payload.name && !body.title) {
     body.title = payload.name;
@@ -558,6 +593,35 @@ const buildProgramWritePayload = (payload: Partial<Program>): Record<string, unk
       body.sub_unit = trimmed ? trimmed : null;
     } else if (subUnit === null) {
       body.sub_unit = null;
+    }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(payload, 'disciplineType') ||
+    Object.prototype.hasOwnProperty.call(payload as any, 'discipline_type') ||
+    Object.prototype.hasOwnProperty.call(payload as any, 'discipline')
+  ) {
+    const disciplineCandidate = Object.prototype.hasOwnProperty.call(payload, 'disciplineType')
+      ? disciplineType
+      : (payload as any).discipline_type ?? (payload as any).discipline;
+    if (typeof disciplineCandidate === 'string') {
+      const trimmed = disciplineCandidate.trim();
+      body.discipline_type = trimmed ? trimmed : null;
+    } else if (disciplineCandidate === null) {
+      body.discipline_type = null;
+    }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(payload, 'department') ||
+    Object.prototype.hasOwnProperty.call(payload as any, 'dept')
+  ) {
+    const departmentCandidate = Object.prototype.hasOwnProperty.call(payload, 'department')
+      ? department
+      : (payload as any).dept;
+    if (typeof departmentCandidate === 'string') {
+      const trimmed = departmentCandidate.trim();
+      body.department = trimmed ? trimmed : null;
+    } else if (departmentCandidate === null) {
+      body.department = null;
     }
   }
   return body;
@@ -1149,6 +1213,8 @@ export const seed = {
       assignedCount: 3,
       organization: 'People Ops',
       subUnit: 'New Hires',
+      disciplineType: 'Technical',
+      department: 'Engineering',
     },
     {
       id: 'p2',
@@ -1160,6 +1226,8 @@ export const seed = {
       assignedCount: 1,
       organization: 'People Ops',
       subUnit: 'Leadership',
+      disciplineType: 'Leadership',
+      department: 'People Ops',
     },
   ] as Program[],
   templates: [


### PR DESCRIPTION
## Summary
- add department and discipline metadata to the Program model and seed data so UI consumers receive the values
- normalize API responses and sanitize write payloads for metadata aliases when creating or updating programs
- cover the new metadata handling with unit tests against the mock API helper

## Testing
- npm test -- programApiMetadata

------
https://chatgpt.com/codex/tasks/task_e_68da282b738c832cbc457bafe7098258