### PR TITLE
Fix RBAC user listing discipline type handling

### DIFF
--- a/__tests__/rbacRoutes.test.js
+++ b/__tests__/rbacRoutes.test.js
@@ -133,6 +133,10 @@ describe('rbac admin routes', () => {
     const targetUser = listRes.body.find(entry => entry.id === userId);
     expect(targetUser).toBeTruthy();
     expect(targetUser.hireDate).toBe(DEFAULT_HIRE_DATE);
+    expect(targetUser).toHaveProperty('discipline_type');
+    expect(targetUser.discipline_type).toBeNull();
+    expect(targetUser).toHaveProperty('discipline');
+    expect(targetUser.discipline).toBe(targetUser.discipline_type);
     expect(targetUser.assigned_programs).toEqual([
       {
         id: programId,

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -2531,7 +2531,6 @@ app.get('/rbac/users', ensureAuth, async (req, res) => {
         u.hire_date,
         u.status,
         u.discipline_type,
-        u.discipline,
         u.last_name,
         u.surname,
         u.first_name,
@@ -2575,7 +2574,6 @@ app.get('/rbac/users', ensureAuth, async (req, res) => {
         u.hire_date,
         u.status,
         u.discipline_type,
-        u.discipline,
         u.last_name,
         u.surname,
         u.first_name,
@@ -2599,7 +2597,6 @@ app.get('/rbac/users', ensureAuth, async (req, res) => {
         u.hire_date,
         u.status,
         u.discipline_type,
-        u.discipline,
         u.last_name,
         u.surname,
         u.first_name,
@@ -2642,7 +2639,6 @@ app.get('/rbac/users', ensureAuth, async (req, res) => {
         u.hire_date,
         u.status,
         u.discipline_type,
-        u.discipline,
         u.last_name,
         u.surname,
         u.first_name,
@@ -2658,6 +2654,7 @@ app.get('/rbac/users', ensureAuth, async (req, res) => {
           assigned_program_pairs: rawPairs,
           roles,
           organization,
+          discipline_type,
           ...userDetails
         } = r;
         const assignments = Array.isArray(rawPairs) ? rawPairs : [];
@@ -2681,9 +2678,12 @@ app.get('/rbac/users', ensureAuth, async (req, res) => {
           })
           .filter(Boolean);
         const hireDateValue = normalizeDateOutput(userDetails.hire_date ?? null);
+        const disciplineTypeValue = discipline_type ?? null;
         return {
           ...userDetails,
           organization,
+          discipline_type: disciplineTypeValue,
+          discipline: disciplineTypeValue,
           hire_date: hireDateValue,
           hireDate: hireDateValue,
           roles: Array.isArray(roles) ? roles : [],
@@ -2701,6 +2701,7 @@ app.get('/rbac/users', ensureAuth, async (req, res) => {
           const {
             assigned_program_pairs: rawPairs,
             roles,
+            discipline_type,
             ...userDetails
           } = r;
           const assignments = Array.isArray(rawPairs) ? rawPairs : [];
@@ -2724,11 +2725,14 @@ app.get('/rbac/users', ensureAuth, async (req, res) => {
             })
             .filter(Boolean);
           const hireDateValue = normalizeDateOutput(userDetails.hire_date ?? null);
+          const disciplineTypeValue = discipline_type ?? null;
           return {
             ...userDetails,
             roles: Array.isArray(roles) ? roles : [],
             hire_date: hireDateValue,
             hireDate: hireDateValue,
+            discipline_type: disciplineTypeValue,
+            discipline: disciplineTypeValue,
             organization: restrictToOrganization ? organizationFilter : null,
             assigned_programs: assignedPrograms,
           };

--- a/public/admin/user-manager.html
+++ b/public/admin/user-manager.html
@@ -1589,11 +1589,31 @@ function buildUserListUrl(params) {
   return `${API}/rbac/users${queryString ? `?${queryString}` : ''}`;
 }
 
+function normalizeUserRecord(user) {
+  if (!user || typeof user !== 'object') {
+    return user;
+  }
+  const {
+    discipline,
+    discipline_type,
+    ...rest
+  } = user;
+  const normalizedDisciplineType = discipline_type ?? null;
+  return {
+    ...rest,
+    discipline_type: normalizedDisciplineType,
+  };
+}
+
 async function listUsers(params) {
   const url = buildUserListUrl(params);
   const r = await fetch(url, { credentials: 'include' });
   if (!r.ok) throw new Error('GET /rbac/users failed');
-  return r.json();
+  const payload = await r.json();
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+  return payload.map(normalizeUserRecord);
 }
 async function listPrograms() {
   const r = await fetch(`${API}/programs`, { credentials: 'include' });


### PR DESCRIPTION
## Summary
- remove the unused discipline column from the /rbac/users queries and derive any discipline response data from discipline_type
- normalize the admin user manager list fetch to depend on discipline_type values only
- extend the RBAC route test to confirm the updated shape returned by /rbac/users

## Testing
- npm test -- rbacRoutes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de9077876c832c9cdbb9c905a7bff9