### PR TITLE
Handle discipline-less schemas in user patch

### DIFF
--- a/orientation_server.js
+++ b/orientation_server.js
@@ -2226,7 +2226,6 @@ app.patch('/api/users/:id', ensureAuth, async (req, res) => {
          username,
          organization,
          hire_date,
-         discipline,
          last_name,
          first_name,
          surname,
@@ -2243,6 +2242,7 @@ app.patch('/api/users/:id', ensureAuth, async (req, res) => {
       [id]
     );
     const responseHireDate = normalizeDateOutput(user.hire_date ?? (hireDateProvided ? normalizedHireDate : null));
+    const responseDisciplineType = user.discipline_type ?? null;
     res.json({
       id: user.id,
       email: user.email,
@@ -2255,8 +2255,8 @@ app.patch('/api/users/:id', ensureAuth, async (req, res) => {
       surname: user.surname ?? null,
       sub_unit: user.sub_unit ?? null,
       department: user.department ?? null,
-      discipline_type: user.discipline_type ?? null,
-      discipline: user.discipline ?? user.discipline_type ?? null,
+      discipline_type: responseDisciplineType,
+      discipline: responseDisciplineType,
       hire_date: responseHireDate,
       hireDate: responseHireDate,
       roles: roleRows.map(r => r.role_key),


### PR DESCRIPTION
## Summary
- stop selecting the legacy discipline column when returning PATCH /api/users/:id responses and derive the value from discipline_type instead
- cover PATCH /api/users/:id with a schema that lacks the discipline column to ensure the handler still succeeds

## Testing
- npm test -- __tests__/rbacRoutes.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de97f08334832cbf70fadfcd50bd26