### PR TITLE
Ensure SendGrid uses fetch shim and add tests

### DIFF
--- a/__tests__/deliverMail.test.js
+++ b/__tests__/deliverMail.test.js
@@ -1,0 +1,78 @@
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_FETCH = global.fetch;
+
+describe('deliverMail SendGrid integration', () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    if (ORIGINAL_FETCH) {
+      global.fetch = ORIGINAL_FETCH;
+    } else {
+      delete global.fetch;
+    }
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('uses SendGrid via undici fetch when global fetch is unavailable', async () => {
+    jest.resetModules();
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    jest.doMock('undici', () => ({ fetch: fetchMock }), { virtual: true });
+
+    process.env = {
+      ...ORIGINAL_ENV,
+      SENDGRID_API_KEY: 'test-key',
+      SENDGRID_FROM_EMAIL: 'from@example.com',
+    };
+    delete process.env.SMTP_URL;
+
+    delete global.fetch;
+
+    const { deliverMail } = require('../orientation_server');
+
+    await deliverMail({
+      to: 'user@example.com',
+      subject: 'Hi there',
+      text: 'Hello from tests',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.sendgrid.com/v3/mail/send');
+    const body = JSON.parse(options.body);
+    expect(body.from.email).toBe('from@example.com');
+  });
+
+  it('surfaces SendGrid delivery failures when no SMTP transport is configured', async () => {
+    jest.resetModules();
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: jest.fn().mockResolvedValue('upstream failure'),
+    });
+    jest.doMock('undici', () => ({ fetch: fetchMock }), { virtual: true });
+
+    const sendMailMock = jest.fn().mockResolvedValue();
+    jest.doMock('nodemailer', () => ({
+      createTransport: jest.fn(() => ({ sendMail: sendMailMock })),
+    }));
+
+    process.env = {
+      ...ORIGINAL_ENV,
+      SENDGRID_API_KEY: 'test-key',
+      SENDGRID_FROM_EMAIL: 'from@example.com',
+    };
+    delete process.env.SMTP_URL;
+
+    delete global.fetch;
+
+    const { deliverMail } = require('../orientation_server');
+
+    await expect(deliverMail({
+      to: 'user@example.com',
+      subject: 'Failure scenario',
+      text: 'This should error',
+    })).rejects.toThrow('sendgrid_error_500');
+
+    expect(sendMailMock).not.toHaveBeenCalled();
+  });
+});

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -108,9 +108,22 @@ const SEND_FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL
   || process.env.SMTP_FROM
   || 'no-reply@example.com';
 const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY || '';
-const hasFetchSupport = typeof fetch === 'function';
+
+let fetchImpl = typeof globalThis.fetch === 'function' ? globalThis.fetch : null;
+if (!fetchImpl) {
+  try {
+    const { fetch: undiciFetch } = require('undici');
+    if (typeof undiciFetch === 'function') {
+      fetchImpl = undiciFetch;
+    }
+  } catch (err) {
+    console.warn('No global fetch found and undici is unavailable; SendGrid delivery disabled');
+  }
+}
+const hasFetchSupport = typeof fetchImpl === 'function';
 const sendgridConfigured = Boolean(SENDGRID_API_KEY && SEND_FROM_EMAIL && hasFetchSupport);
 const SENDGRID_ENDPOINT = 'https://api.sendgrid.com/v3/mail/send';
+const hasSmtpTransport = Boolean(process.env.SMTP_URL);
 
 const escapeHtml = value => {
   if (value === null || value === undefined) return '';
@@ -163,7 +176,7 @@ async function deliverMail(message) {
         const bccList = Array.isArray(payload.bcc) ? payload.bcc : [payload.bcc];
         body.personalizations[0].bcc = bccList.map(email => ({ email }));
       }
-      const response = await fetch(SENDGRID_ENDPOINT, {
+      const response = await fetchImpl(SENDGRID_ENDPOINT, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${SENDGRID_API_KEY}`,
@@ -179,7 +192,12 @@ async function deliverMail(message) {
       }
       return;
     } catch (err) {
-      console.error('SendGrid delivery failed, falling back to SMTP transport', err);
+      if (hasSmtpTransport) {
+        console.error('SendGrid delivery failed, falling back to SMTP transport', err);
+      } else {
+        console.error('SendGrid delivery failed and no SMTP transport is configured', err);
+        throw err;
+      }
     }
   }
   await transporter.sendMail(payload);
@@ -4056,7 +4074,7 @@ if (require.main === module) {
   });
 }
 
-module.exports = { app, pool, ensurePerm, userManagesProgram };
+module.exports = { app, pool, ensurePerm, userManagesProgram, deliverMail };
 
 /*
 ======================

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express": "^4.19.2",
     "express-session": "^1.17.3",
     "nodemailer": "^6.9.11",
+    "undici": "^6.21.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "pg": "^8.11.3",


### PR DESCRIPTION
## Summary
- load an undici-based fetch implementation when running without a global fetch so SendGrid mail delivery still works on Node 16
- surface SendGrid delivery errors whenever no SMTP transport is configured instead of silently swallowing them
- add Jest coverage that exercises deliverMail on a Node environment without global fetch

## Testing
- npm test -- __tests__/deliverMail.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de9ac0ae64832c8125c23e6b01ac87