### PR TITLE
Add department and discipline fields to programs

### DIFF
--- a/migrations/022_add_department_and_discipline_to_programs.sql
+++ b/migrations/022_add_department_and_discipline_to_programs.sql
@@ -1,0 +1,3 @@
+alter table public.programs
+  add column if not exists department text,
+  add column if not exists discipline_type text;

--- a/orientation_server.js
+++ b/orientation_server.js
@@ -2839,7 +2839,9 @@ app.get('/programs', ensurePerm('program.read'), async (req, res) => {
              created_at,
              deleted_at,
              organization,
-             sub_unit
+             sub_unit,
+             department,
+             discipline_type
         from public.programs`;
     if (conds.length) sql += ` where ${conds.join(' and ')}`;
     sql += ' order by created_at desc';
@@ -2861,7 +2863,10 @@ app.post('/programs', ensurePerm('program.create'), async (req, res) => {
       results = null,
       purpose = null,
       organization,
-      sub_unit
+      sub_unit,
+      department = null,
+      discipline_type = null,
+      discipline = null
     } = req.body || {};
     const sanitizedTotalWeeks = sanitizeProgramTotalWeeks(total_weeks);
     const sanitizedDescription = toNullableString(description);
@@ -2869,9 +2874,13 @@ app.post('/programs', ensurePerm('program.create'), async (req, res) => {
     const sanitizedPurpose = toNullableString(purpose);
     const sanitizedOrganization = toNullableString(organization);
     const sanitizedSubUnit = toNullableString(sub_unit);
+    const sanitizedDepartment = toNullableString(department);
+    const sanitizedDisciplineType = toNullableString(
+      discipline_type !== null && discipline_type !== undefined ? discipline_type : discipline
+    );
     const sql = `
-      insert into public.programs (program_id, title, total_weeks, description, results, purpose, organization, sub_unit, created_by)
-      values ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+      insert into public.programs (program_id, title, total_weeks, description, results, purpose, organization, sub_unit, department, discipline_type, created_by)
+      values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
       returning *;`;
     const params = [
       program_id,
@@ -2882,6 +2891,8 @@ app.post('/programs', ensurePerm('program.create'), async (req, res) => {
       sanitizedPurpose,
       sanitizedOrganization,
       sanitizedSubUnit,
+      sanitizedDepartment,
+      sanitizedDisciplineType,
       req.user.id
     ];
     const { rows } = await pool.query(sql, params);
@@ -2904,15 +2915,22 @@ app.patch('/programs/:program_id', ensurePerm('program.update'), async (req, res
     }
     const fields = [];
     const vals = [];
+    const requestBody = req.body && typeof req.body === 'object' ? { ...req.body } : {};
+    if (!Object.prototype.hasOwnProperty.call(requestBody, 'discipline_type')
+      && Object.prototype.hasOwnProperty.call(requestBody, 'discipline')) {
+      requestBody.discipline_type = requestBody.discipline;
+    }
 
-    for (const key of ['title', 'total_weeks', 'description', 'results', 'purpose', 'organization', 'sub_unit']) {
-      if (key in req.body) {
+    const nullableStringKeys = new Set(['organization', 'sub_unit', 'description', 'results', 'purpose', 'department', 'discipline_type']);
+
+    for (const key of ['title', 'total_weeks', 'description', 'results', 'purpose', 'organization', 'sub_unit', 'department', 'discipline_type']) {
+      if (key in requestBody) {
         if (key === 'total_weeks') {
-          vals.push(sanitizeProgramTotalWeeks(req.body[key]));
-        } else if (key === 'organization' || key === 'sub_unit' || key === 'description' || key === 'results' || key === 'purpose') {
-          vals.push(toNullableString(req.body[key]));
+          vals.push(sanitizeProgramTotalWeeks(requestBody[key]));
+        } else if (nullableStringKeys.has(key)) {
+          vals.push(toNullableString(requestBody[key]));
         } else {
-          vals.push(req.body[key]);
+          vals.push(requestBody[key]);
         }
         fields.push(`${key} = $${vals.length}`);
       }

--- a/public/admin/program-template-manager.js
+++ b/public/admin/program-template-manager.js
@@ -1487,6 +1487,8 @@ function normalizeProgramRecord(program) {
     || Object.prototype.hasOwnProperty.call(program, 'disciplineType')) {
     const value = program.discipline ?? program.discipline_type ?? program.disciplineType;
     normalized.discipline = value;
+    normalized.discipline_type = value;
+    normalized.disciplineType = value;
   }
   if (Object.prototype.hasOwnProperty.call(program, 'description')
     || Object.prototype.hasOwnProperty.call(program, 'program_description')
@@ -5840,6 +5842,7 @@ async function submitProgramForm(event) {
     organization: organizationValue ? organizationValue : null,
     sub_unit: subUnitValue ? subUnitValue : null,
     department: departmentValue ? departmentValue : null,
+    discipline_type: disciplineValue ? disciplineValue : null,
     discipline: disciplineValue ? disciplineValue : null,
   };
   const encodedId = targetId ? encodeURIComponent(targetId) : null;


### PR DESCRIPTION
## Summary
- add a migration that introduces nullable `department` and `discipline_type` columns on `public.programs`
- update the orientation server program endpoints to read, write, and patch the new fields (with a `discipline` alias)
- include the new fields in the admin program form payload and normalization so edit modals stay in sync

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de93f01574832c9edc1031bd5ab9f1