### PR TITLE
Align user queries with app_users table

### DIFF
--- a/apps/server/src/services/policy.ts
+++ b/apps/server/src/services/policy.ts
@@ -1,0 +1,49 @@
+import type { Pool } from 'pg';
+
+export interface EnsureUserParams {
+  email: string;
+  displayName?: string | null;
+}
+
+export interface AppUser {
+  user_id: string;
+  email: string;
+  display_name: string | null;
+  last_login_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+const UPSERT_SQL = `
+  insert into app_users (email, display_name, created_at, updated_at, last_login_at)
+  values ($1, $2, now(), now(), now())
+  on conflict (email) do update
+    set display_name = coalesce(excluded.display_name, app_users.display_name),
+        last_login_at = now(),
+        updated_at = now()
+  returning user_id, email, display_name, last_login_at, created_at, updated_at;
+`;
+
+const TOUCH_SQL = `
+  update app_users
+     set last_login_at = now(),
+         updated_at = now()
+   where email = $1
+  returning user_id, email, display_name, last_login_at, created_at, updated_at;
+`;
+
+export async function ensureUser(pool: Pool, params: EnsureUserParams): Promise<AppUser | null> {
+  const email = params.email?.trim().toLowerCase();
+  const displayName = params.displayName?.trim() ?? null;
+  if (!email) {
+    throw new Error('email_required');
+  }
+
+  const result = await pool.query<AppUser>(UPSERT_SQL, [email, displayName]);
+  if (result.rowCount) {
+    return result.rows[0];
+  }
+
+  const touch = await pool.query<AppUser>(TOUCH_SQL, [email]);
+  return touch.rows[0] ?? null;
+}

--- a/auth.js
+++ b/auth.js
@@ -15,22 +15,27 @@ async function registerLocal(req, res){
 
   // Ensure unique username / email
   const exists = await pool.query(
-    'select 1 from public.users where username=$1 or email=$2 limit 1',
+    'select 1 from public.app_users where username=$1 or email=$2 limit 1',
     [username, email || null]
   );
   if (exists.rowCount) return res.status(409).json({ error: 'already_exists' });
 
   const hash = await bcrypt.hash(password, SALT_ROUNDS);
   const upsert = `
-    insert into public.users (username, email, full_name, password_hash, provider)
+    insert into public.app_users (username, email, display_name, password_hash, provider)
     values ($1,$2,$3,$4,'local')
     returning *;`;
   const { rows } = await pool.query(upsert, [username, email || '', full_name || '', hash]);
+  const user = rows[0];
+  const normalizedUser = user ? { ...user, id: user.user_id, full_name: user.display_name } : null;
+  if (!normalizedUser) {
+    return res.status(500).json({ error: 'user_persist_failed' });
+  }
 
   // Log the user in (create session) like Passport does
-  req.login(rows[0], (err) => {
+  req.login(normalizedUser, (err) => {
     if (err) return res.status(500).json({ error: 'session_error' });
-    res.json({ ok: true, user: { id: rows[0].id, username: rows[0].username } });
+    res.json({ ok: true, user: { id: normalizedUser.user_id, username: normalizedUser.username } });
   });
 }
 
@@ -41,18 +46,21 @@ async function loginLocal(req, res){
     return res.status(400).json({ error: 'invalid_credentials' });
   }
 
-  const { rows } = await pool.query('select * from public.users where username=$1 limit 1', [username]);
+  const { rows } = await pool.query('select * from public.app_users where username=$1 limit 1', [username]);
   const user = rows[0];
-  if (!user || !user.password_hash) return res.status(401).json({ error: 'bad_username_or_password' });
+  const normalizedUser = user ? { ...user, id: user.user_id, full_name: user.display_name } : null;
+  if (!normalizedUser || !normalizedUser.password_hash) {
+    return res.status(401).json({ error: 'bad_username_or_password' });
+  }
 
-  const ok = await bcrypt.compare(password, user.password_hash);
+  const ok = await bcrypt.compare(password, normalizedUser.password_hash);
   if (!ok) return res.status(401).json({ error: 'bad_username_or_password' });
 
-  await pool.query('update public.users set last_login_at=now() where id=$1', [user.id]);
+  await pool.query('update public.app_users set last_login_at=now() where user_id=$1', [normalizedUser.user_id]);
 
-  req.login(user, (err) => {
+  req.login(normalizedUser, (err) => {
     if (err) return res.status(500).json({ error: 'session_error' });
-    res.json({ ok: true, user: { id: user.id, username: user.username } });
+    res.json({ ok: true, user: { id: normalizedUser.user_id, username: normalizedUser.username } });
   });
 }
 

--- a/packages/db/migrations/010_app_users_email_unique.sql
+++ b/packages/db/migrations/010_app_users_email_unique.sql
@@ -1,0 +1,14 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND tablename = 'app_users'
+       AND indexname = 'ux_app_users_email'
+  ) THEN
+    CREATE UNIQUE INDEX ux_app_users_email
+      ON public.app_users (email);
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- update local auth SQL to target the existing app_users table and column names
- add a policy ensureUser helper that performs an app_users upsert and returns user_id
- add an idempotent migration that guarantees a unique index on app_users.email

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916389a053c832cbae267684df59698)